### PR TITLE
For discussion: compact field elements

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -109,4 +109,15 @@ void static secp256k1_fe_get_hex(char *r, int *rlen, const secp256k1_fe_t *a);
 /** Convert a hexadecimal string to a field element. */
 void static secp256k1_fe_set_hex(secp256k1_fe_t *r, const char *a, int alen);
 
+
+void static secp256k1_fec_set_fe(secp256k1_fec_t *r, const secp256k1_fe_t *a);
+
+void static secp256k1_fec_get_fe(secp256k1_fe_t *r, const secp256k1_fec_t *a);
+
+void static secp256k1_fec_mul(secp256k1_fec_t *r, const secp256k1_fec_t *a, const secp256k1_fec_t *b);
+
+void static secp256k1_fec_sqr(secp256k1_fec_t *r, const secp256k1_fec_t *a);
+
+void static secp256k1_fec_sqr_pow(secp256k1_fec_t *r, int n);
+
 #endif

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -16,4 +16,8 @@ typedef struct {
 #endif
 } secp256k1_fe_t;
 
+typedef struct {
+    uint64_t n[4];
+} secp256k1_fec_t;
+
 #endif

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -238,4 +238,42 @@ void static secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #endif
 }
 
+void static secp256k1_fec_set_fe(secp256k1_fec_t *r, const secp256k1_fe_t *a) {
+#ifdef VERIFY
+    assert(a->magnitude <= 1);
+#endif
+    const uint64_t t0 = a->n[0], t1 = a->n[1], t2 = a->n[2], t3 = a->n[3], t4 = a->n[4];
+    r->n[0] = (t0      ) | (t1 << 52);
+    r->n[1] = (t1 >> 12) | (t2 << 40);
+    r->n[2] = (t2 >> 24) | (t3 << 28);
+    r->n[3] = (t3 >> 36) | (t4 << 16);
+}
+
+void static secp256k1_fec_get_fe(secp256k1_fe_t *r, const secp256k1_fec_t *a) {
+    const uint64_t t0 = a->n[0], t1 = a->n[1], t2 = a->n[2], t3 = a->n[3];
+    r->n[0] = t0 & 0xFFFFFFFFFFFFFULL;
+    r->n[1] = ((t0 >> 52) | (t1 << 12)) & 0xFFFFFFFFFFFFFULL;
+    r->n[2] = ((t1 >> 40) | (t2 << 24)) & 0xFFFFFFFFFFFFFULL;
+    r->n[3] = ((t2 >> 28) | (t3 << 36)) & 0xFFFFFFFFFFFFFULL;
+    r->n[4] = t3 >> 16;
+#ifdef VERIFY
+    r->magnitude = 1;
+    r->normalized = 0;
+#endif
+}
+
+void static secp256k1_fec_mul(secp256k1_fec_t *r, const secp256k1_fec_t *a, const secp256k1_fec_t *b) {
+    secp256k1_fec_mul_inner(a->n, b->n, r->n);
+}
+
+void static secp256k1_fec_sqr(secp256k1_fec_t *r, const secp256k1_fec_t *a) {
+    secp256k1_fec_sqr_inner(a->n, r->n);
+}
+
+void static secp256k1_fec_sqr_pow(secp256k1_fec_t *r, int n) {
+    for (int i=0; i<n; i++) {
+        secp256k1_fec_sqr_inner(r->n, r->n);
+    }
+}
+
 #endif

--- a/src/field_5x52_int128_impl.h
+++ b/src/field_5x52_int128_impl.h
@@ -102,4 +102,121 @@ void static inline secp256k1_fe_sqr_inner(const uint64_t *a, uint64_t *r) {
 
 }
 
+typedef unsigned __int128 uint128_t;
+
+void static inline secp256k1_fec_mul_inner(const uint64_t *a, const uint64_t *b, uint64_t *r) {
+    uint64_t b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3];
+
+    uint128_t ai = a[0];
+    uint128_t c = ai * b0;
+    uint64_t t0 = (uint64_t)c; c >>= 64;
+    c += ai * b1;
+    uint64_t t1 = (uint64_t)c; c >>= 64;
+    c += ai * b2;
+    uint64_t t2 = (uint64_t)c; c >>= 64;
+    c += ai * b3;
+    uint64_t t3 = (uint64_t)c; c >>= 64;
+    uint64_t t4 = (uint64_t)c;
+
+    ai = a[1];
+    c  = ai * b0 + t1;
+    t1 = (uint64_t)c; c >>= 64;
+    c += ai * b1 + t2;
+    t2 = (uint64_t)c; c >>= 64;
+    c += ai * b2 + t3;
+    t3 = (uint64_t)c; c >>= 64;
+    c += ai * b3 + t4;
+    t4 = (uint64_t)c; c >>= 64;
+    uint64_t t5 = (uint64_t)c;
+
+    ai = a[2];
+    c  = ai * b0 + t2;
+    t2 = (uint64_t)c; c >>= 64;
+    c += ai * b1 + t3;
+    t3 = (uint64_t)c; c >>= 64;
+    c += ai * b2 + t4;
+    t4 = (uint64_t)c; c >>= 64;
+    c += ai * b3 + t5;
+    t5 = (uint64_t)c; c >>= 64;
+    uint64_t t6 = (uint64_t)c;
+
+    ai = a[3];
+    c  = ai * b0 + t3;
+    t3 = (uint64_t)c; c >>= 64;
+    c += ai * b1 + t4;
+    t4 = (uint64_t)c; c >>= 64;
+    c += ai * b2 + t5;
+    t5 = (uint64_t)c; c >>= 64;
+    c += ai * b3 + t6;
+    t6 = (uint64_t)c; c >>= 64;
+
+    c *= 0x1000003D1ULL;
+    c += t3; t3 = (uint64_t)c; c >>= 64;
+    c += t4;
+    c *= 0x1000003D1ULL;
+    c += t0; t0 = (uint64_t)c; c >>= 64;
+
+    c += (uint128_t)t5 * 0x1000003D1ULL + t1; t1 = (uint64_t)c; c >>= 64;
+    c += (uint128_t)t6 * 0x1000003D1ULL + t2; t2 = (uint64_t)c; c >>= 64;
+
+    c += t3; r[3] = (uint64_t)c; c >>= 64;
+    c *= 0x1000003D1ULL;
+    c += t0; r[0] = (uint64_t)c; c >>= 64;
+    c += t1; r[1] = (uint64_t)c; c >>= 64;
+    c += t2; r[2] = (uint64_t)c;
+    assert((c >> 64) == 0);
+}
+
+void static inline secp256k1_fec_sqr_inner(const uint64_t *a, uint64_t *r) {
+    uint64_t a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
+
+    uint128_t m = (uint128_t)a1 * a2;
+    uint128_t c = (uint128_t)a0 * a1;
+    uint64_t t1 = (uint64_t)c; c >>= 64;
+    c += (uint128_t)a0 * a2;
+    uint64_t t2 = (uint64_t)c; c >>= 64;
+    c += (uint128_t)a0 * a3 + (uint64_t)m;
+    uint64_t t3 = (uint64_t)c; c >>= 64;
+    c += (uint128_t)a1 * a3 + (uint64_t)(m >> 64);
+    uint64_t t4 = (uint64_t)c; c >>= 64;
+    c += (uint128_t)a2 * a3;
+    uint64_t t5 = (uint64_t)c; c >>= 64;
+    uint64_t t6 = (uint64_t)c;
+
+    m  = (uint128_t)a0 * a0;
+    uint64_t t0 = (uint64_t)m;
+    c  = ((uint128_t)t1 << 1) + (uint64_t)(m >> 64);
+    t1 = (uint64_t)c; c >>= 64;
+    m  = (uint128_t)a1 * a1;
+    c += ((uint128_t)t2 << 1) + (uint64_t)m;
+    t2 = (uint64_t)c; c >>= 64;
+    c += ((uint128_t)t3 << 1) + (uint64_t)(m >> 64);
+    t3 = (uint64_t)c; c >>= 64;
+    m  = (uint128_t)a2 * a2;
+    c += ((uint128_t)t4 << 1) + (uint64_t)m;
+    t4 = (uint64_t)c; c >>= 64;
+    c += ((uint128_t)t5 << 1) + (uint64_t)(m >> 64);
+    t5 = (uint64_t)c; c >>= 64;
+    m  = (uint128_t)a3 * a3;
+    c += ((uint128_t)t6 << 1) + (uint64_t)m;
+    t6 = (uint64_t)c; c >>= 64;
+    c += (uint64_t)(m >> 64);
+
+    c *= 0x1000003D1ULL;
+    c += t3; t3 = (uint64_t)c; c >>= 64;
+    c += t4;
+    c *= 0x1000003D1ULL;
+    c += t0; t0 = (uint64_t)c; c >>= 64;
+
+    c += (uint128_t)t5 * 0x1000003D1ULL + t1; t1 = (uint64_t)c; c >>= 64;
+    c += (uint128_t)t6 * 0x1000003D1ULL + t2; t2 = (uint64_t)c; c >>= 64;
+
+    c += t3; r[3] = (uint64_t)c; c >>= 64;
+    c *= 0x1000003D1ULL;
+    c += t0; r[0] = (uint64_t)c; c >>= 64;
+    c += t1; r[1] = (uint64_t)c; c >>= 64;
+    c += t2; r[2] = (uint64_t)c;
+    assert((c >> 64) == 0);
+}
+
 #endif

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -68,67 +68,74 @@ int static secp256k1_fe_sqrt(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     // { 2, 22, 223 }. Use an addition chain to calculate 2^n - 1 for each block:
     // 1, [2], 3, 6, 9, 11, [22], 44, 88, 176, 220, [223]
 
-    secp256k1_fe_t x2;
-    secp256k1_fe_sqr(&x2, a);
-    secp256k1_fe_mul(&x2, &x2, a);
+    secp256k1_fe_t an = *a; secp256k1_fe_normalize(&an);
 
-    secp256k1_fe_t x3;
-    secp256k1_fe_sqr(&x3, &x2);
-    secp256k1_fe_mul(&x3, &x3, a);
+    secp256k1_fec_t x1;
+    secp256k1_fec_set_fe(&x1, &an);
 
-    secp256k1_fe_t x6 = x3;
-    for (int j=0; j<3; j++) secp256k1_fe_sqr(&x6, &x6);
-    secp256k1_fe_mul(&x6, &x6, &x3);
+    secp256k1_fec_t x2;
+    secp256k1_fec_sqr(&x2, &x1);
+    secp256k1_fec_mul(&x2, &x2, &x1);
 
-    secp256k1_fe_t x9 = x6;
-    for (int j=0; j<3; j++) secp256k1_fe_sqr(&x9, &x9);
-    secp256k1_fe_mul(&x9, &x9, &x3);
+    secp256k1_fec_t x3;
+    secp256k1_fec_sqr(&x3, &x2);
+    secp256k1_fec_mul(&x3, &x3, &x1);
 
-    secp256k1_fe_t x11 = x9;
-    for (int j=0; j<2; j++) secp256k1_fe_sqr(&x11, &x11);
-    secp256k1_fe_mul(&x11, &x11, &x2);
+    secp256k1_fec_t x6 = x3;
+    secp256k1_fec_sqr_pow(&x6, 3);
+    secp256k1_fec_mul(&x6, &x6, &x3);
 
-    secp256k1_fe_t x22 = x11;
-    for (int j=0; j<11; j++) secp256k1_fe_sqr(&x22, &x22);
-    secp256k1_fe_mul(&x22, &x22, &x11);
+    secp256k1_fec_t x9 = x6;
+    secp256k1_fec_sqr_pow(&x9, 3);
+    secp256k1_fec_mul(&x9, &x9, &x3);
 
-    secp256k1_fe_t x44 = x22;
-    for (int j=0; j<22; j++) secp256k1_fe_sqr(&x44, &x44);
-    secp256k1_fe_mul(&x44, &x44, &x22);
+    secp256k1_fec_t x11 = x9;
+    secp256k1_fec_sqr_pow(&x11, 2);
+    secp256k1_fec_mul(&x11, &x11, &x2);
 
-    secp256k1_fe_t x88 = x44;
-    for (int j=0; j<44; j++) secp256k1_fe_sqr(&x88, &x88);
-    secp256k1_fe_mul(&x88, &x88, &x44);
+    secp256k1_fec_t x22 = x11;
+    secp256k1_fec_sqr_pow(&x22, 11);
+    secp256k1_fec_mul(&x22, &x22, &x11);
 
-    secp256k1_fe_t x176 = x88;
-    for (int j=0; j<88; j++) secp256k1_fe_sqr(&x176, &x176);
-    secp256k1_fe_mul(&x176, &x176, &x88);
+    secp256k1_fec_t x44 = x22;
+    secp256k1_fec_sqr_pow(&x44, 22);
+    secp256k1_fec_mul(&x44, &x44, &x22);
 
-    secp256k1_fe_t x220 = x176;
-    for (int j=0; j<44; j++) secp256k1_fe_sqr(&x220, &x220);
-    secp256k1_fe_mul(&x220, &x220, &x44);
+    secp256k1_fec_t x88 = x44;
+    secp256k1_fec_sqr_pow(&x88, 44);
+    secp256k1_fec_mul(&x88, &x88, &x44);
 
-    secp256k1_fe_t x223 = x220;
-    for (int j=0; j<3; j++) secp256k1_fe_sqr(&x223, &x223);
-    secp256k1_fe_mul(&x223, &x223, &x3);
+    secp256k1_fec_t x176 = x88;
+    secp256k1_fec_sqr_pow(&x176, 88);
+    secp256k1_fec_mul(&x176, &x176, &x88);
+
+    secp256k1_fec_t x220 = x176;
+    secp256k1_fec_sqr_pow(&x220, 44);
+    secp256k1_fec_mul(&x220, &x220, &x44);
+
+    secp256k1_fec_t x223 = x220;
+    secp256k1_fec_sqr_pow(&x223, 3);
+    secp256k1_fec_mul(&x223, &x223, &x3);
 
     // The final result is then assembled using a sliding window over the blocks.
 
-    secp256k1_fe_t t1 = x223;
-    for (int j=0; j<23; j++) secp256k1_fe_sqr(&t1, &t1);
-    secp256k1_fe_mul(&t1, &t1, &x22);
-    for (int j=0; j<6; j++) secp256k1_fe_sqr(&t1, &t1);
-    secp256k1_fe_mul(&t1, &t1, &x2);
-    secp256k1_fe_sqr(&t1, &t1);
-    secp256k1_fe_sqr(r, &t1);
+    secp256k1_fec_t t1 = x223;
+    secp256k1_fec_sqr_pow(&t1, 23);
+    secp256k1_fec_mul(&t1, &t1, &x22);
+    secp256k1_fec_sqr_pow(&t1, 6);
+    secp256k1_fec_mul(&t1, &t1, &x2);
+    secp256k1_fec_sqr_pow(&t1, 2);
+
+    secp256k1_fec_get_fe(r, &t1);
 
     // Check that a square root was actually calculated
 
-    secp256k1_fe_sqr(&t1, r);
-    secp256k1_fe_negate(&t1, &t1, 1);
-    secp256k1_fe_add(&t1, a);
-    secp256k1_fe_normalize(&t1);
-    return secp256k1_fe_is_zero(&t1);
+    secp256k1_fe_t t2;
+    secp256k1_fe_sqr(&t2, r);
+    secp256k1_fe_negate(&t2, &t2, 1);
+    secp256k1_fe_add(&t2, a);
+    secp256k1_fe_normalize(&t2);
+    return secp256k1_fe_is_zero(&t2);
 }
 
 void static secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
@@ -137,61 +144,68 @@ void static secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     // { 1, 2, 22, 223 }. Use an addition chain to calculate 2^n - 1 for each block:
     // [1], [2], 3, 6, 9, 11, [22], 44, 88, 176, 220, [223]
 
-    secp256k1_fe_t x2;
-    secp256k1_fe_sqr(&x2, a);
-    secp256k1_fe_mul(&x2, &x2, a);
+    secp256k1_fe_t an = *a; secp256k1_fe_normalize(&an);
 
-    secp256k1_fe_t x3;
-    secp256k1_fe_sqr(&x3, &x2);
-    secp256k1_fe_mul(&x3, &x3, a);
+    secp256k1_fec_t x1;
+    secp256k1_fec_set_fe(&x1, &an);
 
-    secp256k1_fe_t x6 = x3;
-    for (int j=0; j<3; j++) secp256k1_fe_sqr(&x6, &x6);
-    secp256k1_fe_mul(&x6, &x6, &x3);
+    secp256k1_fec_t x2;
+    secp256k1_fec_sqr(&x2, &x1);
+    secp256k1_fec_mul(&x2, &x2, &x1);
 
-    secp256k1_fe_t x9 = x6;
-    for (int j=0; j<3; j++) secp256k1_fe_sqr(&x9, &x9);
-    secp256k1_fe_mul(&x9, &x9, &x3);
+    secp256k1_fec_t x3;
+    secp256k1_fec_sqr(&x3, &x2);
+    secp256k1_fec_mul(&x3, &x3, &x1);
 
-    secp256k1_fe_t x11 = x9;
-    for (int j=0; j<2; j++) secp256k1_fe_sqr(&x11, &x11);
-    secp256k1_fe_mul(&x11, &x11, &x2);
+    secp256k1_fec_t x6 = x3;
+    secp256k1_fec_sqr_pow(&x6, 3);
+    secp256k1_fec_mul(&x6, &x6, &x3);
 
-    secp256k1_fe_t x22 = x11;
-    for (int j=0; j<11; j++) secp256k1_fe_sqr(&x22, &x22);
-    secp256k1_fe_mul(&x22, &x22, &x11);
+    secp256k1_fec_t x9 = x6;
+    secp256k1_fec_sqr_pow(&x9, 3);
+    secp256k1_fec_mul(&x9, &x9, &x3);
 
-    secp256k1_fe_t x44 = x22;
-    for (int j=0; j<22; j++) secp256k1_fe_sqr(&x44, &x44);
-    secp256k1_fe_mul(&x44, &x44, &x22);
+    secp256k1_fec_t x11 = x9;
+    secp256k1_fec_sqr_pow(&x11, 2);
+    secp256k1_fec_mul(&x11, &x11, &x2);
 
-    secp256k1_fe_t x88 = x44;
-    for (int j=0; j<44; j++) secp256k1_fe_sqr(&x88, &x88);
-    secp256k1_fe_mul(&x88, &x88, &x44);
+    secp256k1_fec_t x22 = x11;
+    secp256k1_fec_sqr_pow(&x22, 11);
+    secp256k1_fec_mul(&x22, &x22, &x11);
 
-    secp256k1_fe_t x176 = x88;
-    for (int j=0; j<88; j++) secp256k1_fe_sqr(&x176, &x176);
-    secp256k1_fe_mul(&x176, &x176, &x88);
+    secp256k1_fec_t x44 = x22;
+    secp256k1_fec_sqr_pow(&x44, 22);
+    secp256k1_fec_mul(&x44, &x44, &x22);
 
-    secp256k1_fe_t x220 = x176;
-    for (int j=0; j<44; j++) secp256k1_fe_sqr(&x220, &x220);
-    secp256k1_fe_mul(&x220, &x220, &x44);
+    secp256k1_fec_t x88 = x44;
+    secp256k1_fec_sqr_pow(&x88, 44);
+    secp256k1_fec_mul(&x88, &x88, &x44);
 
-    secp256k1_fe_t x223 = x220;
-    for (int j=0; j<3; j++) secp256k1_fe_sqr(&x223, &x223);
-    secp256k1_fe_mul(&x223, &x223, &x3);
+    secp256k1_fec_t x176 = x88;
+    secp256k1_fec_sqr_pow(&x176, 88);
+    secp256k1_fec_mul(&x176, &x176, &x88);
+
+    secp256k1_fec_t x220 = x176;
+    secp256k1_fec_sqr_pow(&x220, 44);
+    secp256k1_fec_mul(&x220, &x220, &x44);
+
+    secp256k1_fec_t x223 = x220;
+    secp256k1_fec_sqr_pow(&x223, 3);
+    secp256k1_fec_mul(&x223, &x223, &x3);
 
     // The final result is then assembled using a sliding window over the blocks.
 
-    secp256k1_fe_t t1 = x223;
-    for (int j=0; j<23; j++) secp256k1_fe_sqr(&t1, &t1);
-    secp256k1_fe_mul(&t1, &t1, &x22);
-    for (int j=0; j<5; j++) secp256k1_fe_sqr(&t1, &t1);
-    secp256k1_fe_mul(&t1, &t1, a);
-    for (int j=0; j<3; j++) secp256k1_fe_sqr(&t1, &t1);
-    secp256k1_fe_mul(&t1, &t1, &x2);
-    for (int j=0; j<2; j++) secp256k1_fe_sqr(&t1, &t1);
-    secp256k1_fe_mul(r, &t1, a);
+    secp256k1_fec_t t1 = x223;
+    secp256k1_fec_sqr_pow(&t1, 23);
+    secp256k1_fec_mul(&t1, &t1, &x22);
+    secp256k1_fec_sqr_pow(&t1, 5);
+    secp256k1_fec_mul(&t1, &t1, &x1);
+    secp256k1_fec_sqr_pow(&t1, 3);
+    secp256k1_fec_mul(&t1, &t1, &x2);
+    secp256k1_fec_sqr_pow(&t1, 2);
+    secp256k1_fec_mul(&t1, &t1, &x1);
+
+    secp256k1_fec_get_fe(r, &t1);
 }
 
 void static secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {


### PR DESCRIPTION
- secp256k1_fec_t: compact field element representation
- secp256k1_fec_* methods: import/export, mul/sqr/sqr_pow
- only field "64bit" at the moment (no asm)
- sqrt and constant-time inversion changed to use this

A compact representation allows faster multiplication/squaring, although the overheads of converting back and forth make it unwieldy in the point formulae. Nevertheless, sqrt and Fermat-based inversion require >256 consecutive mul/sqr operations, making the conversion worthwhile.

The measured performance improvement for isolated secp256k1_fe_sqrt testing (and by extension secp256k1_fe_inv) is around %18, including all overheads.
