### PR TITLE
Effectively affine precomp A for _ecmult without inversion!

### DIFF
--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -50,7 +50,7 @@ static void secp256k1_ecmult_gen_start(void) {
         VERIFY_CHECK(secp256k1_ge_set_xo_var(&nums_ge, &nums_x, 0));
         secp256k1_gej_set_ge(&nums_gej, &nums_ge);
         /* Add G to make the bits in x uniformly distributed. */
-        secp256k1_gej_add_ge_var(&nums_gej, &nums_gej, g);
+        secp256k1_gej_add_ge_var(&nums_gej, &nums_gej, NULL, g);
     }
 
     /* compute prec. */

--- a/src/group.h
+++ b/src/group.h
@@ -116,12 +116,15 @@ static void secp256k1_gej_add_ge(secp256k1_gej_t *r, const secp256k1_gej_t *a, c
 /** Set r equal to the sum of a and b (with b given in affine coordinates). This is more efficient
     than secp256k1_gej_add_var. It is identical to secp256k1_gej_add_ge but without constant-time
     guarantee, and b is allowed to be infinity. */
-static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b);
+static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_fe_t *azr, const secp256k1_ge_t *b);
 
 /** Get a hex representation of a point. *rlen will be overwritten with the real length. */
 static void secp256k1_gej_get_hex(char *r, int *rlen, const secp256k1_gej_t *a);
 
 #ifdef USE_ENDOMORPHISM
+/** Set r to be equal to lambda times a, where lambda is chosen in a way such that this is very fast. */
+static void secp256k1_ge_mul_lambda(secp256k1_ge_t *r, const secp256k1_ge_t *a);
+
 /** Set r to be equal to lambda times a, where lambda is chosen in a way such that this is very fast. */
 static void secp256k1_gej_mul_lambda(secp256k1_gej_t *r, const secp256k1_gej_t *a);
 #endif

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -296,11 +296,18 @@ static void secp256k1_gej_add_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, 
     secp256k1_fe_add(&r->y, &h3);
 }
 
-static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b) {
+static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_fe_t *azr, const secp256k1_ge_t *b) {
     if (a->infinity) {
         r->infinity = b->infinity;
-        r->x = b->x;
-        r->y = b->y;
+        if (azr == NULL) {
+            r->x = b->x;
+            r->y = b->y;
+        } else {
+            secp256k1_fe_t azr2; secp256k1_fe_sqr(&azr2, azr);
+            secp256k1_fe_t azr3; secp256k1_fe_mul(&azr3, &azr2, azr);
+            secp256k1_fe_mul(&r->x, &b->x, &azr2);
+            secp256k1_fe_mul(&r->y, &b->y, &azr3);
+        }
         secp256k1_fe_set_int(&r->z, 1);
         return;
     }
@@ -309,11 +316,19 @@ static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *
         return;
     }
     r->infinity = 0;
-    secp256k1_fe_t z12; secp256k1_fe_sqr(&z12, &a->z);
+
+    secp256k1_fe_t az;
+    if (azr == NULL) {
+        az = a->z;
+    } else {
+        secp256k1_fe_mul(&az, &a->z, azr);
+    }
+
+    secp256k1_fe_t z12; secp256k1_fe_sqr(&z12, &az);
     secp256k1_fe_t u1 = a->x; secp256k1_fe_normalize_weak(&u1);
     secp256k1_fe_t u2; secp256k1_fe_mul(&u2, &b->x, &z12);
     secp256k1_fe_t s1 = a->y; secp256k1_fe_normalize_weak(&s1);
-    secp256k1_fe_t s2; secp256k1_fe_mul(&s2, &b->y, &z12); secp256k1_fe_mul(&s2, &s2, &a->z);
+    secp256k1_fe_t s2; secp256k1_fe_mul(&s2, &b->y, &z12); secp256k1_fe_mul(&s2, &s2, &az);
     secp256k1_fe_t h; secp256k1_fe_negate(&h, &u1, 1); secp256k1_fe_add(&h, &u2);
     secp256k1_fe_t i; secp256k1_fe_negate(&i, &s1, 1); secp256k1_fe_add(&i, &s2);
     if (secp256k1_fe_normalizes_to_zero_var(&h)) {
@@ -415,6 +430,12 @@ static void secp256k1_gej_get_hex(char *r, int *rlen, const secp256k1_gej_t *a) 
 }
 
 #ifdef USE_ENDOMORPHISM
+static void secp256k1_ge_mul_lambda(secp256k1_ge_t *r, const secp256k1_ge_t *a) {
+    const secp256k1_fe_t *beta = &secp256k1_ge_consts->beta;
+    *r = *a;
+    secp256k1_fe_mul(&r->x, &r->x, beta);
+}
+
 static void secp256k1_gej_mul_lambda(secp256k1_gej_t *r, const secp256k1_gej_t *a) {
     const secp256k1_fe_t *beta = &secp256k1_ge_consts->beta;
     *r = *a;
@@ -428,13 +449,13 @@ static void secp256k1_coz_dblu_impl_var(secp256k1_coz_t *r, secp256k1_coz_t *ra,
     secp256k1_fe_t L; secp256k1_fe_sqr(&L, &E);
     secp256k1_fe_t M; secp256k1_fe_sqr(&M, &a->x); secp256k1_fe_mul_int(&M, 3);
     secp256k1_fe_t *S = &ra->x; secp256k1_fe_mul(S, &a->x, &E); secp256k1_fe_mul_int(S, 4);
-    secp256k1_fe_normalize_var(S);
+    secp256k1_fe_normalize_weak(S);
     *rzr = a->y; secp256k1_fe_mul_int(rzr, 2);
     secp256k1_fe_t t; secp256k1_fe_negate(&t, S, 1); secp256k1_fe_mul_int(&t, 2);
     secp256k1_fe_sqr(&r->x, &M); secp256k1_fe_add(&r->x, &t);
     secp256k1_fe_negate(&t, &r->x, 5); secp256k1_fe_add(&t, S);
     secp256k1_fe_mul(&r->y, &M, &t);
-    ra->y = L; secp256k1_fe_mul_int(&ra->y, 8); secp256k1_fe_normalize_var(&ra->y);
+    ra->y = L; secp256k1_fe_mul_int(&ra->y, 8); secp256k1_fe_normalize_weak(&ra->y);
     secp256k1_fe_negate(&t, &ra->y, 1); secp256k1_fe_add(&r->y, &t);
 }
 
@@ -458,18 +479,16 @@ static void secp256k1_coz_zaddu_var(secp256k1_gej_t *r, secp256k1_coz_t *ra, sec
         return;
     }
 
-    secp256k1_fe_t X1 = ra->x; secp256k1_fe_normalize_var(&X1);
-    secp256k1_fe_t Y1 = ra->y; secp256k1_fe_normalize_var(&Y1);
-    secp256k1_fe_t X2 = b->x; secp256k1_fe_normalize_var(&X2);
-    secp256k1_fe_t Y2 = b->y; secp256k1_fe_normalize_var(&Y2);
+    secp256k1_fe_t X1 = ra->x; secp256k1_fe_normalize_weak(&X1);
+    secp256k1_fe_t Y1 = ra->y; secp256k1_fe_normalize_weak(&Y1);
+    secp256k1_fe_t X2 = b->x; secp256k1_fe_normalize_weak(&X2);
+    secp256k1_fe_t Y2 = b->y; secp256k1_fe_normalize_weak(&Y2);
 
     secp256k1_fe_t dX; secp256k1_fe_negate(&dX, &X2, 1); secp256k1_fe_add(&dX, &X1);
     secp256k1_fe_t dY; secp256k1_fe_negate(&dY, &Y1, 1); secp256k1_fe_add(&dY, &Y2);
 
-    secp256k1_fe_normalize_var(&dX);
-    if (secp256k1_fe_is_zero(&dX)) {
-        secp256k1_fe_normalize_var(&dY);
-        if (secp256k1_fe_is_zero(&dY)) {
+    if (secp256k1_fe_normalizes_to_zero_var(&dX)) {
+        if (secp256k1_fe_normalizes_to_zero_var(&dY)) {
             secp256k1_coz_dblu_impl_var((secp256k1_coz_t*)r, ra, rzr, b);
             secp256k1_fe_mul(&r->z, &b->z, rzr);
         } else {

--- a/src/tests.c
+++ b/src/tests.c
@@ -839,12 +839,12 @@ void test_ge(void) {
     secp256k1_gej_t iij; secp256k1_gej_add_var(&iij, &ij, &ij);
 
     /* gej + ge adds */
-    secp256k1_gej_t aa; secp256k1_gej_add_ge_var(&aa, &aj, &a);
-    secp256k1_gej_t ab; secp256k1_gej_add_ge_var(&ab, &aj, &b);
-    secp256k1_gej_t ai; secp256k1_gej_add_ge_var(&ai, &aj, &i);
-    secp256k1_gej_t an; secp256k1_gej_add_ge_var(&an, &aj, &n);
-    secp256k1_gej_t ia; secp256k1_gej_add_ge_var(&ia, &ij, &a);
-    secp256k1_gej_t ii; secp256k1_gej_add_ge_var(&ii, &ij, &i);
+    secp256k1_gej_t aa; secp256k1_gej_add_ge_var(&aa, &aj, NULL, &a);
+    secp256k1_gej_t ab; secp256k1_gej_add_ge_var(&ab, &aj, NULL, &b);
+    secp256k1_gej_t ai; secp256k1_gej_add_ge_var(&ai, &aj, NULL, &i);
+    secp256k1_gej_t an; secp256k1_gej_add_ge_var(&an, &aj, NULL, &n);
+    secp256k1_gej_t ia; secp256k1_gej_add_ge_var(&ia, &ij, NULL, &a);
+    secp256k1_gej_t ii; secp256k1_gej_add_ge_var(&ii, &ij, NULL, &i);
 
     /* const gej + ge adds */
     secp256k1_gej_t aac; secp256k1_gej_add_ge(&aac, &aj, &a);


### PR DESCRIPTION
- Builds on top of https://github.com/bitcoin/secp256k1/pull/41 (Co-Z arithmetic for precomputation).
- Instead of inversion, scales all precomp A points to the same Z (usually != 1).
- Store the precomp A as affine by discarding the z coordinate (whilst noting the single Z value for later), which is equivalent to taking them as affine points on an isogenous curve.
- In secp256k1_ecmult, we treat the accumulator ("r") as operating on this isogenous curve.
- Doubling formula needs no changes, adding of precomp A points is a simple _gej_add_ge_var.
- G precomp remains the same, but each add of these requires an extra 1M to bring the accumulator temporarily back to the "default isogeny". For simplicity here I've modified _gej_add_ge_var to support this.
- The z value of the final result needs to be scaled (1M) also.
- Optimal at WINDOW_A=5.

Anyway, the upshot of this is an ~5% performance improvement for bench_verify (64bit, endo=yes), over and above the Co-Z precomputation itself, so >8% total vs master. Rough math suggests it's saving ~116M vs the Co-Z arithmetic PR, which appears to make any inversion approach obsolete.

Questions welcome, as I'm not sure how to explain this in a straight-forward way (as far as I know this is a novel idea). I guess it's important to understand why the isogeny works out so neatly; it's a rather nice property of secp256k1 that stems from it having a==0 in the curve equation; otherwise, operating on an isogenous curve would require changes to the doubling formula. I recommend e.g. http://joye.site88.net/papers/TJ10coordblind.pdf, where this is discussed in the context of blinding (which reminds me I was meaning to PR a demo of that), albeit the a==0 case is not explicitly called out. It may be easier just to think of it as playing games with the z values...

EDIT: I'll leave it as I wrote it, but I think the above should be talking about isomorphisms rather than isogenies.