### PR TITLE
Use secp256k1_fe_equal_var in secp256k1_fe_sqrt_var.

### DIFF
--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -31,6 +31,7 @@ static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
     r &= (d[8] <= 0x3FFFFFFUL * m);
     r &= (d[9] <= 0x03FFFFFUL * m);
     r &= (a->magnitude >= 0);
+    r &= (a->magnitude <= 32);
     if (a->normalized) {
         r &= (a->magnitude <= 1);
         if (r && (d[9] == 0x03FFFFFUL)) {

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -43,6 +43,7 @@ static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
     r &= (d[3] <= 0xFFFFFFFFFFFFFULL * m);
     r &= (d[4] <= 0x0FFFFFFFFFFFFULL * m);
     r &= (a->magnitude >= 0);
+    r &= (a->magnitude <= 2048);
     if (a->normalized) {
         r &= (a->magnitude <= 1);
         if (r && (d[4] == 0x0FFFFFFFFFFFFULL) && ((d[3] & d[2] & d[1]) == 0xFFFFFFFFFFFFFULL)) {

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -135,10 +135,7 @@ static int secp256k1_fe_sqrt_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     /* Check that a square root was actually calculated */
 
     secp256k1_fe_sqr(&t1, r);
-    secp256k1_fe_negate(&t1, &t1, 1);
-    secp256k1_fe_add(&t1, a);
-    secp256k1_fe_normalize_var(&t1);
-    return secp256k1_fe_is_zero(&t1);
+    return secp256k1_fe_equal_var(&t1, a);
 }
 
 static void secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a) {


### PR DESCRIPTION
In theory this should be faster, since secp256k1_fe_equal_var is able to
 shortcut the normalization.  On x86_64 the improvement appears to be in
 the noise for me.  At least it makes the code cleaner.