### PR TITLE
Add scalar blinding for ecmult_gen()

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -328,6 +328,18 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
   const unsigned char *tweak
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(4);
 
+/** Updates the context randomization.
+ *  Returns: 1: randomization successfully updated
+ *           0: error
+ *  In:      ctx:       pointer to a context object (cannot be NULL)
+ *           seed32:    pointer to a 32-byte random seed (NULL resets to initial state)
+ */
+SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
+  secp256k1_context_t* ctx,
+  const unsigned char *seed32
+) SECP256K1_ARG_NONNULL(1);
+
+
 # ifdef __cplusplus
 }
 # endif

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -24,6 +24,8 @@ typedef struct {
      * the intermediate sums while computing a*G.
      */
     secp256k1_ge_storage_t (*prec)[64][16]; /* prec[j][i] = 16^j * i * G + U_i */
+    secp256k1_scalar_t blind;
+    secp256k1_gej_t initial;
 } secp256k1_ecmult_gen_context_t;
 
 static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context_t* ctx);
@@ -35,5 +37,7 @@ static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_cont
 
 /** Multiply with the generator: R = a*G */
 static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context_t* ctx, secp256k1_gej_t *r, const secp256k1_scalar_t *a);
+
+static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context_t *ctx, const unsigned char *seed32);
 
 #endif

--- a/src/group.h
+++ b/src/group.h
@@ -115,4 +115,7 @@ static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_stor
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
 static void secp256k1_ge_storage_cmov(secp256k1_ge_storage_t *r, const secp256k1_ge_storage_t *a, int flag);
 
+/** Rescale a jacobian point by b which must be non-zero. Constant-time. */
+static void secp256k1_gej_rescale(secp256k1_gej_t *r, const secp256k1_fe_t *b);
+
 #endif

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -396,6 +396,17 @@ static void secp256k1_gej_add_ge(secp256k1_gej_t *r, const secp256k1_gej_t *a, c
     r->infinity = infinity;
 }
 
+static void secp256k1_gej_rescale(secp256k1_gej_t *r, const secp256k1_fe_t *s) {
+    /* Operations: 4 mul, 1 sqr */
+    secp256k1_fe_t zz;
+    VERIFY_CHECK(!secp256k1_fe_is_zero(s));
+    secp256k1_fe_sqr(&zz, s);
+    secp256k1_fe_mul(&r->x, &r->x, &zz);                /* r->x *= s^2 */
+    secp256k1_fe_mul(&r->y, &r->y, &zz);
+    secp256k1_fe_mul(&r->y, &r->y, s);                  /* r->y *= s^3 */
+    secp256k1_fe_mul(&r->z, &r->z, s);                  /* r->z *= s   */
+}
+
 static void secp256k1_ge_to_storage(secp256k1_ge_storage_t *r, const secp256k1_ge_t *a) {
     secp256k1_fe_t x, y;
     VERIFY_CHECK(!a->infinity);

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -410,3 +410,10 @@ int secp256k1_ec_privkey_import(const secp256k1_context_t* ctx, unsigned char *s
     secp256k1_scalar_clear(&key);
     return ret;
 }
+
+int secp256k1_context_randomize(secp256k1_context_t* ctx, const unsigned char *seed32) {
+    DEBUG_CHECK(ctx != NULL);
+    DEBUG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
+    secp256k1_ecmult_gen_blind(&ctx->ecmult_gen_ctx, seed32);
+    return 1;
+}


### PR DESCRIPTION
This computes (n-b)G + bG with random value b, in place of nG.

This is intended to reduce exposure to potential power/EMI sidechannels
 during signing and pubkey generation by blinding the secret value with
 another value which is hopefully unknown to the attacker.

It may not be very helpful if the attacker is able to observe the setup
 or if even the scalar addition has an unacceptable leak, but it has low
 overhead in any case and the security should be purely additive on top
 of the existing defenses against sidechannels.

For comments right now, there is no interface presented for users to pass in a seed. We should probably change the API to use a context pointer created by start, and could change start to take a random uchar[32] at that time.