### PR TITLE
Reduce the amount of runtime-initialized constants

### DIFF
--- a/src/bench_inv.c
+++ b/src/bench_inv.c
@@ -42,11 +42,7 @@ void bench_inv(void* arg) {
 }
 
 int main(void) {
-    secp256k1_ge_start();
-
     bench_inv_t data;
     run_benchmark(bench_inv, bench_inv_setup, NULL, &data, 10, 20000);
-
-    secp256k1_ge_stop();
     return 0;
 }

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -37,8 +37,7 @@ static void secp256k1_ecmult_gen_start(void) {
     secp256k1_ecmult_gen_consts_t *ret = (secp256k1_ecmult_gen_consts_t*)checked_malloc(sizeof(secp256k1_ecmult_gen_consts_t));
 
     /* get the generator */
-    const secp256k1_ge_t *g = &secp256k1_ge_consts->g;
-    secp256k1_gej_t gj; secp256k1_gej_set_ge(&gj, g);
+    secp256k1_gej_t gj; secp256k1_gej_set_ge(&gj, &secp256k1_ge_const_g);
 
     /* Construct a group element with no known corresponding scalar (nothing up my sleeve). */
     secp256k1_gej_t nums_gej;
@@ -50,7 +49,7 @@ static void secp256k1_ecmult_gen_start(void) {
         VERIFY_CHECK(secp256k1_ge_set_xo_var(&nums_ge, &nums_x, 0));
         secp256k1_gej_set_ge(&nums_gej, &nums_ge);
         /* Add G to make the bits in x uniformly distributed. */
-        secp256k1_gej_add_ge_var(&nums_gej, &nums_gej, g);
+        secp256k1_gej_add_ge_var(&nums_gej, &nums_gej, &secp256k1_ge_const_g);
     }
 
     /* compute prec. */

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -91,8 +91,7 @@ static void secp256k1_ecmult_start(void) {
     secp256k1_ecmult_consts_t *ret = (secp256k1_ecmult_consts_t*)checked_malloc(sizeof(secp256k1_ecmult_consts_t));
 
     /* get the generator */
-    const secp256k1_ge_t *g = &secp256k1_ge_consts->g;
-    secp256k1_gej_t gj; secp256k1_gej_set_ge(&gj, g);
+    secp256k1_gej_t gj; secp256k1_gej_set_ge(&gj, &secp256k1_ge_const_g);
 
 #ifdef USE_ENDOMORPHISM
     /* calculate 2^128*generator */

--- a/src/field.h
+++ b/src/field.h
@@ -30,21 +30,6 @@
 #error "Please select field implementation"
 #endif
 
-typedef struct {
-#ifndef USE_NUM_NONE
-    secp256k1_num_t p;
-#endif
-    secp256k1_fe_t order;
-} secp256k1_fe_consts_t;
-
-static const secp256k1_fe_consts_t *secp256k1_fe_consts = NULL;
-
-/** Initialize field element precomputation data. */
-static void secp256k1_fe_start(void);
-
-/** Unload field element precomputation data. */
-static void secp256k1_fe_stop(void);
-
 /** Normalize a field element. */
 static void secp256k1_fe_normalize(secp256k1_fe_t *r);
 

--- a/src/field_10x26.h
+++ b/src/field_10x26.h
@@ -18,4 +18,23 @@ typedef struct {
 #endif
 } secp256k1_fe_t;
 
+#define SECP256K1_FE_CONST_INNER(d7, d6, d5, d4, d3, d2, d1, d0) { \
+    (d0) & 0x3FFFFFFUL, \
+    ((d0) >> 26) | ((d1) & 0xFFFFFUL) << 6, \
+    ((d1) >> 20) | ((d2) & 0x3FFFUL) << 12, \
+    ((d2) >> 14) | ((d3) & 0xFFUL) << 18, \
+    ((d3) >> 8) | ((d4) & 0x3) << 24, \
+    ((d4) >> 2) & 0x3FFFFFFUL, \
+    ((d4) >> 28) | ((d5) & 0x3FFFFFUL) << 4, \
+    ((d5) >> 22) | ((d6) & 0xFFFF) << 10, \
+    ((d6) >> 16) | ((d7) & 0x3FF) << 16, \
+    ((d7) >> 10) \
+}
+
+#ifdef VERIFY
+#define SECP256K1_FE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {SECP256K1_FE_CONST_INNER((d7), (d6), (d5), (d4), (d3), (d2), (d1), (d0)), 1, 1}
+#else
+#define SECP256K1_FE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {SECP256K1_FE_CONST_INNER((d7), (d6), (d5), (d4), (d3), (d2), (d1), (d0))}
+#endif
+
 #endif

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -13,9 +13,6 @@
 #include "num.h"
 #include "field.h"
 
-static void secp256k1_fe_inner_start(void) {}
-static void secp256k1_fe_inner_stop(void) {}
-
 #ifdef VERIFY
 static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
     const uint32_t *d = a->n;

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -18,4 +18,18 @@ typedef struct {
 #endif
 } secp256k1_fe_t;
 
+#define SECP256K1_FE_CONST_INNER(d7, d6, d5, d4, d3, d2, d1, d0) { \
+    (d0) | ((uint64_t)(d1) & 0xFFFFFUL) << 32, \
+    ((d1) >> 20) | ((uint64_t)(d2)) << 12 | ((uint64_t)(d3) & 0xFFUL) << 44, \
+    ((d3) >> 8) | ((uint64_t)(d4) & 0xFFFFFFFUL) << 24, \
+    ((d4) >> 28) | ((uint64_t)(d5)) << 4 | ((uint64_t)(d6) & 0xFFFFUL) << 36, \
+    ((d6) >> 16) | ((uint64_t)(d7)) << 16 \
+}
+
+#ifdef VERIFY
+#define SECP256K1_FE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {SECP256K1_FE_CONST_INNER((d7), (d6), (d5), (d4), (d3), (d2), (d1), (d0)), 1, 1}
+#else
+#define SECP256K1_FE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {SECP256K1_FE_CONST_INNER((d7), (d6), (d5), (d4), (d3), (d2), (d1), (d0))}
+#endif
+
 #endif

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -30,9 +30,6 @@
  *  output.
  */
 
-static void secp256k1_fe_inner_start(void) {}
-static void secp256k1_fe_inner_stop(void) {}
-
 #ifdef VERIFY
 static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
     const uint64_t *d = a->n;

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -206,13 +206,20 @@ static void secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #if defined(USE_FIELD_INV_BUILTIN)
     secp256k1_fe_inv(r, a);
 #elif defined(USE_FIELD_INV_NUM)
+    static const unsigned char prime[32] = {
+        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+        0xFF,0xFF,0xFF,0xFE,0xFF,0xFF,0xFC,0x2F
+    };
     unsigned char b[32];
     secp256k1_fe_t c = *a;
     secp256k1_fe_normalize_var(&c);
     secp256k1_fe_get_b32(b, &c);
-    secp256k1_num_t n;
+    secp256k1_num_t n, m;
     secp256k1_num_set_bin(&n, b, 32);
-    secp256k1_num_mod_inverse(&n, &n, &secp256k1_fe_consts->p);
+    secp256k1_num_set_bin(&m, prime, 32);
+    secp256k1_num_mod_inverse(&n, &n, &m);
     secp256k1_num_get_bin(b, 32, &n);
     VERIFY_CHECK(secp256k1_fe_set_b32(r, b));
 #else
@@ -242,34 +249,6 @@ static void secp256k1_fe_inv_all_var(size_t len, secp256k1_fe_t r[len], const se
     }
 
     r[0] = u;
-}
-
-static void secp256k1_fe_start(void) {
-#ifndef USE_NUM_NONE
-    static const unsigned char secp256k1_fe_consts_p[] = {
-        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
-        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
-        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
-        0xFF,0xFF,0xFF,0xFE,0xFF,0xFF,0xFC,0x2F
-    };
-#endif
-    if (secp256k1_fe_consts == NULL) {
-        secp256k1_fe_inner_start();
-        secp256k1_fe_consts_t *ret = (secp256k1_fe_consts_t*)checked_malloc(sizeof(secp256k1_fe_consts_t));
-#ifndef USE_NUM_NONE
-        secp256k1_num_set_bin(&ret->p, secp256k1_fe_consts_p, sizeof(secp256k1_fe_consts_p));
-#endif
-        secp256k1_fe_consts = ret;
-    }
-}
-
-static void secp256k1_fe_stop(void) {
-    if (secp256k1_fe_consts != NULL) {
-        secp256k1_fe_consts_t *c = (secp256k1_fe_consts_t*)secp256k1_fe_consts;
-        free((void*)c);
-        secp256k1_fe_consts = NULL;
-        secp256k1_fe_inner_stop();
-    }
 }
 
 #endif

--- a/src/group.h
+++ b/src/group.h
@@ -25,24 +25,6 @@ typedef struct {
     int infinity; /* whether this represents the point at infinity */
 } secp256k1_gej_t;
 
-/** Global constants related to the group */
-typedef struct {
-    secp256k1_ge_t g; /* the generator point */
-
-#ifdef USE_ENDOMORPHISM
-    /* constants related to secp256k1's efficiently computable endomorphism */
-    secp256k1_fe_t beta;
-#endif
-} secp256k1_ge_consts_t;
-
-static const secp256k1_ge_consts_t *secp256k1_ge_consts = NULL;
-
-/** Initialize the group module. */
-static void secp256k1_ge_start(void);
-
-/** De-initialize the group module. */
-static void secp256k1_ge_stop(void);
-
 /** Set a group element equal to the point at infinity */
 static void secp256k1_ge_set_infinity(secp256k1_ge_t *r);
 

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -21,9 +21,6 @@
 #error "Please select scalar implementation"
 #endif
 
-static void secp256k1_scalar_start(void);
-static void secp256k1_scalar_stop(void);
-
 /** Clear a scalar to prevent the leak of sensitive data. */
 static void secp256k1_scalar_clear(secp256k1_scalar_t *r);
 

--- a/src/scalar_4x64.h
+++ b/src/scalar_4x64.h
@@ -14,4 +14,6 @@ typedef struct {
     uint64_t d[4];
 } secp256k1_scalar_t;
 
+#define SECP256K1_SCALAR_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{((uint64_t)(d1)) << 32 | (d0), ((uint64_t)(d3)) << 32 | (d2), ((uint64_t)(d5)) << 32 | (d4), ((uint64_t)(d7)) << 32 | (d6)}}
+
 #endif

--- a/src/scalar_8x32.h
+++ b/src/scalar_8x32.h
@@ -14,4 +14,6 @@ typedef struct {
     uint32_t d[8];
 } secp256k1_scalar_t;
 
+#define SECP256K1_SCALAR_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{(d0), (d1), (d2), (d3), (d4), (d5), (d6), (d7)}}
+
 #endif

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -24,121 +24,6 @@
 #error "Please select scalar implementation"
 #endif
 
-typedef struct {
-#ifndef USE_NUM_NONE
-    secp256k1_num_t order;
-#endif
-#ifdef USE_ENDOMORPHISM
-    secp256k1_scalar_t minus_lambda, minus_b1, minus_b2, g1, g2;
-#endif
-} secp256k1_scalar_consts_t;
-
-static const secp256k1_scalar_consts_t *secp256k1_scalar_consts = NULL;
-
-static void secp256k1_scalar_start(void) {
-    if (secp256k1_scalar_consts != NULL)
-        return;
-
-    /* Allocate. */
-    secp256k1_scalar_consts_t *ret = (secp256k1_scalar_consts_t*)checked_malloc(sizeof(secp256k1_scalar_consts_t));
-
-#ifndef USE_NUM_NONE
-    static const unsigned char secp256k1_scalar_consts_order[] = {
-        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
-        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFE,
-        0xBA,0xAE,0xDC,0xE6,0xAF,0x48,0xA0,0x3B,
-        0xBF,0xD2,0x5E,0x8C,0xD0,0x36,0x41,0x41
-    };
-    secp256k1_num_set_bin(&ret->order, secp256k1_scalar_consts_order, sizeof(secp256k1_scalar_consts_order));
-#endif
-#ifdef USE_ENDOMORPHISM
-    /**
-     * Lambda is a scalar which has the property for secp256k1 that point multiplication by
-     * it is efficiently computable (see secp256k1_gej_mul_lambda). */
-    static const unsigned char secp256k1_scalar_consts_lambda[32] = {
-         0x53,0x63,0xad,0x4c,0xc0,0x5c,0x30,0xe0,
-         0xa5,0x26,0x1c,0x02,0x88,0x12,0x64,0x5a,
-         0x12,0x2e,0x22,0xea,0x20,0x81,0x66,0x78,
-         0xdf,0x02,0x96,0x7c,0x1b,0x23,0xbd,0x72
-    };
-    /**
-     * "Guide to Elliptic Curve Cryptography" (Hankerson, Menezes, Vanstone) gives an algorithm
-     * (algorithm 3.74) to find k1 and k2 given k, such that k1 + k2 * lambda == k mod n, and k1
-     * and k2 have a small size.
-     * It relies on constants a1, b1, a2, b2. These constants for the value of lambda above are:
-     *
-     * - a1 =      {0x30,0x86,0xd2,0x21,0xa7,0xd4,0x6b,0xcd,0xe8,0x6c,0x90,0xe4,0x92,0x84,0xeb,0x15}
-     * - b1 =     -{0xe4,0x43,0x7e,0xd6,0x01,0x0e,0x88,0x28,0x6f,0x54,0x7f,0xa9,0x0a,0xbf,0xe4,0xc3}
-     * - a2 = {0x01,0x14,0xca,0x50,0xf7,0xa8,0xe2,0xf3,0xf6,0x57,0xc1,0x10,0x8d,0x9d,0x44,0xcf,0xd8}
-     * - b2 =      {0x30,0x86,0xd2,0x21,0xa7,0xd4,0x6b,0xcd,0xe8,0x6c,0x90,0xe4,0x92,0x84,0xeb,0x15}
-     *
-     * The algorithm then computes c1 = round(b1 * k / n) and c2 = round(b2 * k / n), and gives
-     * k1 = k - (c1*a1 + c2*a2) and k2 = -(c1*b1 + c2*b2). Instead, we use modular arithmetic, and
-     * compute k1 as k - k2 * lambda, avoiding the need for constants a1 and a2.
-     *
-     * g1, g2 are precomputed constants used to replace division with a rounded multiplication
-     * when decomposing the scalar for an endomorphism-based point multiplication.
-     *
-     * The possibility of using precomputed estimates is mentioned in "Guide to Elliptic Curve
-     * Cryptography" (Hankerson, Menezes, Vanstone) in section 3.5.
-     *
-     * The derivation is described in the paper "Efficient Software Implementation of Public-Key
-     * Cryptography on Sensor Networks Using the MSP430X Microcontroller" (Gouvea, Oliveira, Lopez),
-     * Section 4.3 (here we use a somewhat higher-precision estimate):
-     * d = a1*b2 - b1*a2
-     * g1 = round((2^272)*b2/d)
-     * g2 = round((2^272)*b1/d)
-     *
-     * (Note that 'd' is also equal to the curve order here because [a1,b1] and [a2,b2] are found
-     * as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
-     */
-    static const unsigned char secp256k1_scalar_consts_minus_b1[32] = {
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-        0xe4,0x43,0x7e,0xd6,0x01,0x0e,0x88,0x28,
-        0x6f,0x54,0x7f,0xa9,0x0a,0xbf,0xe4,0xc3
-    };
-    static const unsigned char secp256k1_scalar_consts_b2[32] = {
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-        0x30,0x86,0xd2,0x21,0xa7,0xd4,0x6b,0xcd,
-        0xe8,0x6c,0x90,0xe4,0x92,0x84,0xeb,0x15
-    };
-    static const unsigned char secp256k1_scalar_consts_g1[32] = {
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00,0x00,0x00,0x30,0x86,
-        0xd2,0x21,0xa7,0xd4,0x6b,0xcd,0xe8,0x6c,
-        0x90,0xe4,0x92,0x84,0xeb,0x15,0x3d,0xab
-    };
-    static const unsigned char secp256k1_scalar_consts_g2[32] = {
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00,0x00,0x00,0xe4,0x43,
-        0x7e,0xd6,0x01,0x0e,0x88,0x28,0x6f,0x54,
-        0x7f,0xa9,0x0a,0xbf,0xe4,0xc4,0x22,0x12
-    };
-
-    secp256k1_scalar_set_b32(&ret->minus_lambda, secp256k1_scalar_consts_lambda, NULL);
-    secp256k1_scalar_negate(&ret->minus_lambda, &ret->minus_lambda);
-    secp256k1_scalar_set_b32(&ret->minus_b1, secp256k1_scalar_consts_minus_b1, NULL);
-    secp256k1_scalar_set_b32(&ret->minus_b2, secp256k1_scalar_consts_b2, NULL);
-    secp256k1_scalar_negate(&ret->minus_b2, &ret->minus_b2);
-    secp256k1_scalar_set_b32(&ret->g1, secp256k1_scalar_consts_g1, NULL);
-    secp256k1_scalar_set_b32(&ret->g2, secp256k1_scalar_consts_g2, NULL);
-#endif
-
-    /* Set the global pointer. */
-    secp256k1_scalar_consts = ret;
-}
-
-static void secp256k1_scalar_stop(void) {
-    if (secp256k1_scalar_consts == NULL)
-        return;
-
-    secp256k1_scalar_consts_t *c = (secp256k1_scalar_consts_t*)secp256k1_scalar_consts;
-    secp256k1_scalar_consts = NULL;
-    free(c);
-}
-
 #ifndef USE_NUM_NONE
 static void secp256k1_scalar_get_num(secp256k1_num_t *r, const secp256k1_scalar_t *a) {
     unsigned char c[32];
@@ -147,7 +32,13 @@ static void secp256k1_scalar_get_num(secp256k1_num_t *r, const secp256k1_scalar_
 }
 
 static void secp256k1_scalar_order_get_num(secp256k1_num_t *r) {
-    *r = secp256k1_scalar_consts->order;
+    static const unsigned char order[32] = {
+        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
+        0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFE,
+        0xBA,0xAE,0xDC,0xE6,0xAF,0x48,0xA0,0x3B,
+        0xBF,0xD2,0x5E,0x8C,0xD0,0x36,0x41,0x41
+    };
+    secp256k1_num_set_bin(r, order, 32);
 }
 #endif
 
@@ -308,9 +199,10 @@ static void secp256k1_scalar_inverse_var(secp256k1_scalar_t *r, const secp256k1_
 #elif defined(USE_SCALAR_INV_NUM)
     unsigned char b[32];
     secp256k1_scalar_get_b32(b, x);
-    secp256k1_num_t n;
+    secp256k1_num_t n, m;
     secp256k1_num_set_bin(&n, b, 32);
-    secp256k1_num_mod_inverse(&n, &n, &secp256k1_scalar_consts->order);
+    secp256k1_scalar_order_get_num(&m);
+    secp256k1_num_mod_inverse(&n, &n, &m);
     secp256k1_num_get_bin(b, 32, &n);
     secp256k1_scalar_set_b32(r, b, NULL);
 #else
@@ -319,16 +211,74 @@ static void secp256k1_scalar_inverse_var(secp256k1_scalar_t *r, const secp256k1_
 }
 
 #ifdef USE_ENDOMORPHISM
+/**
+ * The Secp256k1 curve has an endomorphism, where lambda * (x, y) = (beta * x, y), where
+ * lambda is {0x53,0x63,0xad,0x4c,0xc0,0x5c,0x30,0xe0,0xa5,0x26,0x1c,0x02,0x88,0x12,0x64,0x5a,
+ *            0x12,0x2e,0x22,0xea,0x20,0x81,0x66,0x78,0xdf,0x02,0x96,0x7c,0x1b,0x23,0xbd,0x72}
+ *
+ * "Guide to Elliptic Curve Cryptography" (Hankerson, Menezes, Vanstone) gives an algorithm
+ * (algorithm 3.74) to find k1 and k2 given k, such that k1 + k2 * lambda == k mod n, and k1
+ * and k2 have a small size.
+ * It relies on constants a1, b1, a2, b2. These constants for the value of lambda above are:
+ *
+ * - a1 =      {0x30,0x86,0xd2,0x21,0xa7,0xd4,0x6b,0xcd,0xe8,0x6c,0x90,0xe4,0x92,0x84,0xeb,0x15}
+ * - b1 =     -{0xe4,0x43,0x7e,0xd6,0x01,0x0e,0x88,0x28,0x6f,0x54,0x7f,0xa9,0x0a,0xbf,0xe4,0xc3}
+ * - a2 = {0x01,0x14,0xca,0x50,0xf7,0xa8,0xe2,0xf3,0xf6,0x57,0xc1,0x10,0x8d,0x9d,0x44,0xcf,0xd8}
+ * - b2 =      {0x30,0x86,0xd2,0x21,0xa7,0xd4,0x6b,0xcd,0xe8,0x6c,0x90,0xe4,0x92,0x84,0xeb,0x15}
+ *
+ * The algorithm then computes c1 = round(b1 * k / n) and c2 = round(b2 * k / n), and gives
+ * k1 = k - (c1*a1 + c2*a2) and k2 = -(c1*b1 + c2*b2). Instead, we use modular arithmetic, and
+ * compute k1 as k - k2 * lambda, avoiding the need for constants a1 and a2.
+ *
+ * g1, g2 are precomputed constants used to replace division with a rounded multiplication
+ * when decomposing the scalar for an endomorphism-based point multiplication.
+ *
+ * The possibility of using precomputed estimates is mentioned in "Guide to Elliptic Curve
+ * Cryptography" (Hankerson, Menezes, Vanstone) in section 3.5.
+ *
+ * The derivation is described in the paper "Efficient Software Implementation of Public-Key
+ * Cryptography on Sensor Networks Using the MSP430X Microcontroller" (Gouvea, Oliveira, Lopez),
+ * Section 4.3 (here we use a somewhat higher-precision estimate):
+ * d = a1*b2 - b1*a2
+ * g1 = round((2^272)*b2/d)
+ * g2 = round((2^272)*b1/d)
+ *
+ * (Note that 'd' is also equal to the curve order here because [a1,b1] and [a2,b2] are found
+ * as outputs of the Extended Euclidean Algorithm on inputs 'order' and 'lambda').
+ *
+ * The function below splits a in r1 and r2, such that r1 + lambda * r2 == a (mod order).
+ */
+
 static void secp256k1_scalar_split_lambda_var(secp256k1_scalar_t *r1, secp256k1_scalar_t *r2, const secp256k1_scalar_t *a) {
+    static const secp256k1_scalar_t minus_lambda = SECP256K1_SCALAR_CONST(
+        0xAC9C52B3UL, 0x3FA3CF1FUL, 0x5AD9E3FDUL, 0x77ED9BA4UL,
+        0xA880B9FCUL, 0x8EC739C2UL, 0xE0CFC810UL, 0xB51283CFUL
+    );
+    static const secp256k1_scalar_t minus_b1 = SECP256K1_SCALAR_CONST(
+        0x00000000UL, 0x00000000UL, 0x00000000UL, 0x00000000UL,
+        0xE4437ED6UL, 0x010E8828UL, 0x6F547FA9UL, 0x0ABFE4C3UL
+    );
+    static const secp256k1_scalar_t minus_b2 = SECP256K1_SCALAR_CONST(
+        0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFEUL,
+        0x8A280AC5UL, 0x0774346DUL, 0xD765CDA8UL, 0x3DB1562CUL
+    );
+    static const secp256k1_scalar_t g1 = SECP256K1_SCALAR_CONST(
+        0x00000000UL, 0x00000000UL, 0x00000000UL, 0x00003086UL,
+        0xD221A7D4UL, 0x6BCDE86CUL, 0x90E49284UL, 0xEB153DABUL
+    );
+    static const secp256k1_scalar_t g2 = SECP256K1_SCALAR_CONST(
+        0x00000000UL, 0x00000000UL, 0x00000000UL, 0x0000E443UL,
+        0x7ED6010EUL, 0x88286F54UL, 0x7FA90ABFUL, 0xE4C42212UL
+    );
     VERIFY_CHECK(r1 != a);
     VERIFY_CHECK(r2 != a);
     secp256k1_scalar_t c1, c2;
-    secp256k1_scalar_mul_shift_var(&c1, a, &secp256k1_scalar_consts->g1, 272);
-    secp256k1_scalar_mul_shift_var(&c2, a, &secp256k1_scalar_consts->g2, 272);
-    secp256k1_scalar_mul(&c1, &c1, &secp256k1_scalar_consts->minus_b1);
-    secp256k1_scalar_mul(&c2, &c2, &secp256k1_scalar_consts->minus_b2);
+    secp256k1_scalar_mul_shift_var(&c1, a, &g1, 272);
+    secp256k1_scalar_mul_shift_var(&c2, a, &g2, 272);
+    secp256k1_scalar_mul(&c1, &c1, &minus_b1);
+    secp256k1_scalar_mul(&c2, &c2, &minus_b2);
     secp256k1_scalar_add(r2, &c1, &c2);
-    secp256k1_scalar_mul(r1, r2, &secp256k1_scalar_consts->minus_lambda);
+    secp256k1_scalar_mul(r1, r2, &minus_lambda);
     secp256k1_scalar_add(r1, r1, a);
 }
 #endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -20,9 +20,6 @@
 #include "hash_impl.h"
 
 void secp256k1_start(unsigned int flags) {
-    secp256k1_fe_start();
-    secp256k1_ge_start();
-    secp256k1_ecdsa_start();
     if (flags & SECP256K1_START_SIGN) {
         secp256k1_ecmult_gen_start();
     }
@@ -34,9 +31,6 @@ void secp256k1_start(unsigned int flags) {
 void secp256k1_stop(void) {
     secp256k1_ecmult_stop();
     secp256k1_ecmult_gen_stop();
-    secp256k1_ecdsa_stop();
-    secp256k1_ge_stop();
-    secp256k1_fe_stop();
 }
 
 int secp256k1_ecdsa_verify(const unsigned char *msg32, const unsigned char *sig, int siglen, const unsigned char *pubkey, int pubkeylen) {

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -22,7 +22,6 @@
 void secp256k1_start(unsigned int flags) {
     secp256k1_fe_start();
     secp256k1_ge_start();
-    secp256k1_scalar_start();
     secp256k1_ecdsa_start();
     if (flags & SECP256K1_START_SIGN) {
         secp256k1_ecmult_gen_start();
@@ -36,7 +35,6 @@ void secp256k1_stop(void) {
     secp256k1_ecmult_stop();
     secp256k1_ecmult_gen_stop();
     secp256k1_ecdsa_stop();
-    secp256k1_scalar_stop();
     secp256k1_ge_stop();
     secp256k1_fe_stop();
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -1657,11 +1657,6 @@ int main(int argc, char **argv) {
     /* initializing a second time shouldn't cause any harm or memory leaks. */
     secp256k1_start(SECP256K1_START_SIGN | SECP256K1_START_VERIFY);
 
-    /* Likewise, re-running the internal init functions should be harmless. */
-    secp256k1_fe_start();
-    secp256k1_ge_start();
-    secp256k1_ecdsa_start();
-
     run_sha256_tests();
     run_hmac_sha256_tests();
     run_rfc6979_hmac_sha256_tests();
@@ -1706,10 +1701,5 @@ int main(int argc, char **argv) {
 
     /* shutting down twice shouldn't cause any double frees. */
     secp256k1_stop();
-
-    /* Same for the internal shutdown functions. */
-    secp256k1_fe_stop();
-    secp256k1_ge_stop();
-    secp256k1_ecdsa_stop();
     return 0;
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -1660,7 +1660,6 @@ int main(int argc, char **argv) {
     /* Likewise, re-running the internal init functions should be harmless. */
     secp256k1_fe_start();
     secp256k1_ge_start();
-    secp256k1_scalar_start();
     secp256k1_ecdsa_start();
 
     run_sha256_tests();
@@ -1711,7 +1710,6 @@ int main(int argc, char **argv) {
     /* Same for the internal shutdown functions. */
     secp256k1_fe_stop();
     secp256k1_ge_stop();
-    secp256k1_scalar_stop();
     secp256k1_ecdsa_stop();
     return 0;
 }


### PR DESCRIPTION
Instead of having per-subsystem context that gets initialized at runtime, use some macros to write them directly as C static consts. Less code, faster, more readable.