### PR TITLE
Shouldn't this be #ifdef?

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -27,7 +27,7 @@
 } while(0)
 #endif
 
-#ifndef HAVE_BUILTIN_EXPECT
+#ifdef HAVE_BUILTIN_EXPECT
 #define EXPECT(x,c) __builtin_expect((x),(c))
 #else
 #define EXPECT(x,c) (x)


### PR DESCRIPTION
Right now I have to define HAVE_BUILTIN_EXPECT to get it to compile with IAR EWARM where __builtin_expect() dosen't exist, shouldn't it be the opposite?