### PR TITLE
Introduce compact storage types

### DIFF
--- a/src/field.h
+++ b/src/field.h
@@ -117,7 +117,6 @@ static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_f
 static void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_storage_t*);
 
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
-static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag);
 static void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag);
 
 #endif

--- a/src/field.h
+++ b/src/field.h
@@ -110,7 +110,14 @@ static void secp256k1_fe_get_hex(char *r64, const secp256k1_fe_t *a);
 /** Convert a 64-character hexadecimal string to a field element. */
 static int secp256k1_fe_set_hex(secp256k1_fe_t *r, const char *a64);
 
+/** Convert a field element to the storage type. */
+static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_fe_t*);
+
+/** Convert a field element back from the storage type. */
+static void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_storage_t*);
+
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
 static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag);
+static void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag);
 
 #endif

--- a/src/field_10x26.h
+++ b/src/field_10x26.h
@@ -37,4 +37,10 @@ typedef struct {
 #define SECP256K1_FE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {SECP256K1_FE_CONST_INNER((d7), (d6), (d5), (d4), (d3), (d2), (d1), (d0))}
 #endif
 
+typedef struct {
+    uint32_t n[8];
+} secp256k1_fe_storage_t;
+
+#define SECP256K1_FE_STORAGE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{ (d0), (d1), (d2), (d3), (d4), (d5), (d6), (d7) }}
+
 #endif

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -1083,4 +1083,47 @@ static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int fl
 #endif
 }
 
+static inline void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag) {
+    uint32_t mask0 = flag + ~((uint32_t)0), mask1 = ~mask0;
+    r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
+    r->n[1] = (r->n[1] & mask0) | (a->n[1] & mask1);
+    r->n[2] = (r->n[2] & mask0) | (a->n[2] & mask1);
+    r->n[3] = (r->n[3] & mask0) | (a->n[3] & mask1);
+    r->n[4] = (r->n[4] & mask0) | (a->n[4] & mask1);
+    r->n[5] = (r->n[5] & mask0) | (a->n[5] & mask1);
+    r->n[6] = (r->n[6] & mask0) | (a->n[6] & mask1);
+    r->n[7] = (r->n[7] & mask0) | (a->n[7] & mask1);
+}
+
+static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_fe_t *a) {
+#ifdef VERIFY
+    VERIFY_CHECK(a->normalized);
+#endif
+    r->n[0] = a->n[0] | a->n[1] << 26;
+    r->n[1] = a->n[1] >> 6 | a->n[2] << 20;
+    r->n[2] = a->n[2] >> 12 | a->n[3] << 14;
+    r->n[3] = a->n[3] >> 18 | a->n[4] << 8;
+    r->n[4] = a->n[4] >> 24 | a->n[5] << 2 | a->n[6] << 28;
+    r->n[5] = a->n[6] >> 4 | a->n[7] << 22;
+    r->n[6] = a->n[7] >> 10 | a->n[8] << 16;
+    r->n[7] = a->n[8] >> 16 | a->n[9] << 10;
+}
+
+static inline void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_storage_t *a) {
+    r->n[0] = a->n[0] & 0x3FFFFFFUL;
+    r->n[1] = a->n[0] >> 26 | ((a->n[1] << 6) & 0x3FFFFFFUL);
+    r->n[2] = a->n[1] >> 20 | ((a->n[2] << 12) & 0x3FFFFFFUL);
+    r->n[3] = a->n[2] >> 14 | ((a->n[3] << 18) & 0x3FFFFFFUL);
+    r->n[4] = a->n[3] >> 8 | ((a->n[4] << 24) & 0x3FFFFFFUL);
+    r->n[5] = (a->n[4] >> 2) & 0x3FFFFFFUL;
+    r->n[6] = a->n[4] >> 28 | ((a->n[5] << 4) & 0x3FFFFFFUL);
+    r->n[7] = a->n[5] >> 22 | ((a->n[6] << 10) & 0x3FFFFFFUL);
+    r->n[8] = a->n[6] >> 16 | ((a->n[7] << 16) & 0x3FFFFFFUL);
+    r->n[9] = a->n[7] >> 10;
+#ifdef VERIFY
+    r->magnitude = 1;
+    r->normalized = 1;
+#endif
+}
+
 #endif

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -1063,26 +1063,6 @@ static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #endif
 }
 
-static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag) {
-    uint32_t mask0 = flag + ~((uint32_t)0), mask1 = ~mask0;
-    r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
-    r->n[1] = (r->n[1] & mask0) | (a->n[1] & mask1);
-    r->n[2] = (r->n[2] & mask0) | (a->n[2] & mask1);
-    r->n[3] = (r->n[3] & mask0) | (a->n[3] & mask1);
-    r->n[4] = (r->n[4] & mask0) | (a->n[4] & mask1);
-    r->n[5] = (r->n[5] & mask0) | (a->n[5] & mask1);
-    r->n[6] = (r->n[6] & mask0) | (a->n[6] & mask1);
-    r->n[7] = (r->n[7] & mask0) | (a->n[7] & mask1);
-    r->n[8] = (r->n[8] & mask0) | (a->n[8] & mask1);
-    r->n[9] = (r->n[9] & mask0) | (a->n[9] & mask1);
-#ifdef VERIFY
-    if (flag) {
-        r->magnitude = a->magnitude;
-        r->normalized = a->normalized;
-    }
-#endif
-}
-
 static inline void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag) {
     uint32_t mask0 = flag + ~((uint32_t)0), mask1 = ~mask0;
     r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -32,4 +32,15 @@ typedef struct {
 #define SECP256K1_FE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {SECP256K1_FE_CONST_INNER((d7), (d6), (d5), (d4), (d3), (d2), (d1), (d0))}
 #endif
 
+typedef struct {
+    uint64_t n[4];
+} secp256k1_fe_storage_t;
+
+#define SECP256K1_FE_STORAGE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{ \
+    (d0) | ((uint64_t)(d1)) << 32, \
+    (d2) | ((uint64_t)(d3)) << 32, \
+    (d4) | ((uint64_t)(d5)) << 32, \
+    (d6) | ((uint64_t)(d7)) << 32 \
+}}
+
 #endif

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -398,21 +398,6 @@ static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #endif
 }
 
-static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag) {
-    uint64_t mask0 = flag + ~((uint64_t)0), mask1 = ~mask0;
-    r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
-    r->n[1] = (r->n[1] & mask0) | (a->n[1] & mask1);
-    r->n[2] = (r->n[2] & mask0) | (a->n[2] & mask1);
-    r->n[3] = (r->n[3] & mask0) | (a->n[3] & mask1);
-    r->n[4] = (r->n[4] & mask0) | (a->n[4] & mask1);
-#ifdef VERIFY
-    if (flag) {
-        r->magnitude = a->magnitude;
-        r->normalized = a->normalized;
-    }
-#endif
-}
-
 static inline void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag) {
     uint64_t mask0 = flag + ~((uint64_t)0), mask1 = ~mask0;
     r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -413,4 +413,34 @@ static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int fl
 #endif
 }
 
+static inline void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag) {
+    uint64_t mask0 = flag + ~((uint64_t)0), mask1 = ~mask0;
+    r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
+    r->n[1] = (r->n[1] & mask0) | (a->n[1] & mask1);
+    r->n[2] = (r->n[2] & mask0) | (a->n[2] & mask1);
+    r->n[3] = (r->n[3] & mask0) | (a->n[3] & mask1);
+}
+
+static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_fe_t *a) {
+#ifdef VERIFY
+    VERIFY_CHECK(a->normalized);
+#endif
+    r->n[0] = a->n[0] | a->n[1] << 52;
+    r->n[1] = a->n[1] >> 12 | a->n[2] << 40;
+    r->n[2] = a->n[2] >> 24 | a->n[3] << 28;
+    r->n[3] = a->n[3] >> 36 | a->n[4] << 16;
+}
+
+static inline void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_storage_t *a) {
+    r->n[0] = a->n[0] & 0xFFFFFFFFFFFFFULL;
+    r->n[1] = a->n[0] >> 52 | ((a->n[1] << 12) & 0xFFFFFFFFFFFFFULL);
+    r->n[2] = a->n[1] >> 40 | ((a->n[2] << 24) & 0xFFFFFFFFFFFFFULL);
+    r->n[3] = a->n[2] >> 28 | ((a->n[3] << 36) & 0xFFFFFFFFFFFFFULL);
+    r->n[4] = a->n[3] >> 16;
+#ifdef VERIFY
+    r->magnitude = 1;
+    r->normalized = 1;
+#endif
+}
+
 #endif

--- a/src/group.h
+++ b/src/group.h
@@ -25,6 +25,11 @@ typedef struct {
     int infinity; /* whether this represents the point at infinity */
 } secp256k1_gej_t;
 
+typedef struct {
+    secp256k1_fe_storage_t x;
+    secp256k1_fe_storage_t y;
+} secp256k1_ge_storage_t;
+
 /** Set a group element equal to the point at infinity */
 static void secp256k1_ge_set_infinity(secp256k1_ge_t *r);
 
@@ -98,5 +103,11 @@ static void secp256k1_gej_clear(secp256k1_gej_t *r);
 
 /** Clear a secp256k1_ge_t to prevent leaking sensitive information. */
 static void secp256k1_ge_clear(secp256k1_ge_t *r);
+
+/** Convert a group element to the storage type. */
+static void secp256k1_ge_to_storage(secp256k1_ge_storage_t *r, const secp256k1_ge_t*);
+
+/** Convert a group element back from the storage type. */
+static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_storage_t*);
 
 #endif

--- a/src/group.h
+++ b/src/group.h
@@ -110,4 +110,7 @@ static void secp256k1_ge_to_storage(secp256k1_ge_storage_t *r, const secp256k1_g
 /** Convert a group element back from the storage type. */
 static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_storage_t*);
 
+/** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
+static void secp256k1_ge_storage_cmov(secp256k1_ge_storage_t *r, const secp256k1_ge_storage_t *a, int flag);
+
 #endif

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -392,6 +392,23 @@ static void secp256k1_gej_get_hex(char *r131, const secp256k1_gej_t *a) {
     secp256k1_ge_get_hex(r131, &t);
 }
 
+static void secp256k1_ge_to_storage(secp256k1_ge_storage_t *r, const secp256k1_ge_t *a) {
+    secp256k1_fe_t x, y;
+    VERIFY_CHECK(!a->infinity);
+    x = a->x;
+    secp256k1_fe_normalize(&x);
+    y = a->y;
+    secp256k1_fe_normalize(&y);
+    secp256k1_fe_to_storage(&r->x, &x);
+    secp256k1_fe_to_storage(&r->y, &y);
+}
+
+static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_storage_t *a) {
+    secp256k1_fe_from_storage(&r->x, &a->x);
+    secp256k1_fe_from_storage(&r->y, &a->y);
+    r->infinity = 0;
+}
+
 #ifdef USE_ENDOMORPHISM
 static void secp256k1_gej_mul_lambda(secp256k1_gej_t *r, const secp256k1_gej_t *a) {
     static const secp256k1_fe_t beta = SECP256K1_FE_CONST(

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -409,6 +409,11 @@ static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_stor
     r->infinity = 0;
 }
 
+static SECP256K1_INLINE void secp256k1_ge_storage_cmov(secp256k1_ge_storage_t *r, const secp256k1_ge_storage_t *a, int flag) {
+    secp256k1_fe_storage_cmov(&r->x, &a->x, flag);
+    secp256k1_fe_storage_cmov(&r->y, &a->y, flag);
+}
+
 #ifdef USE_ENDOMORPHISM
 static void secp256k1_gej_mul_lambda(secp256k1_gej_t *r, const secp256k1_gej_t *a) {
     static const secp256k1_fe_t beta = SECP256K1_FE_CONST(

--- a/src/tests.c
+++ b/src/tests.c
@@ -685,12 +685,18 @@ void run_field_misc(void) {
         z = x;
         secp256k1_fe_add(&z,&y);
         secp256k1_fe_normalize(&z);
-        /* Test the conditional move. */
-        secp256k1_fe_cmov(&z, &x, 0);
-        CHECK(secp256k1_fe_equal_var(&x, &z) == 0);
-        CHECK(secp256k1_fe_cmp_var(&x, &z) != 0);
-        secp256k1_fe_cmov(&y, &x, 1);
-        CHECK(secp256k1_fe_equal_var(&x, &y));
+        /* Test storage conversion and conditional moves. */
+        secp256k1_fe_storage_t xs, ys, zs;
+        secp256k1_fe_to_storage(&xs, &x);
+        secp256k1_fe_to_storage(&ys, &y);
+        secp256k1_fe_to_storage(&zs, &z);
+        secp256k1_fe_storage_cmov(&zs, &xs, 0);
+        CHECK(memcmp(&xs, &zs, sizeof(xs)) != 0);
+        secp256k1_fe_storage_cmov(&ys, &xs, 1);
+        CHECK(memcmp(&xs, &ys, sizeof(xs)) == 0);
+        secp256k1_fe_from_storage(&x, &xs);
+        secp256k1_fe_from_storage(&y, &ys);
+        secp256k1_fe_from_storage(&z, &zs);
         /* Test that mul_int, mul, and add agree. */
         secp256k1_fe_add(&y, &x);
         secp256k1_fe_add(&y, &x);

--- a/src/tests.c
+++ b/src/tests.c
@@ -627,6 +627,42 @@ int check_fe_inverse(const secp256k1_fe_t *a, const secp256k1_fe_t *ai) {
     return check_fe_equal(&x, &one);
 }
 
+void run_field_convert(void) {
+    static const unsigned char b32[32] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
+        0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x40
+    };
+    static const char *c64 = "0001020304050607111213141516171822232425262728293334353637383940";
+    static const secp256k1_fe_storage_t fes = SECP256K1_FE_STORAGE_CONST(
+        0x00010203UL, 0x04050607UL, 0x11121314UL, 0x15161718UL,
+        0x22232425UL, 0x26272829UL, 0x33343536UL, 0x37383940UL
+    );
+    static const secp256k1_fe_t fe = SECP256K1_FE_CONST(
+        0x00010203UL, 0x04050607UL, 0x11121314UL, 0x15161718UL,
+        0x22232425UL, 0x26272829UL, 0x33343536UL, 0x37383940UL
+    );
+    secp256k1_fe_t fe2;
+    unsigned char b322[32];
+    char c642[64];
+    secp256k1_fe_storage_t fes2;
+    /* Check conversions to fe. */
+    CHECK(secp256k1_fe_set_b32(&fe2, b32));
+    CHECK(secp256k1_fe_equal_var(&fe, &fe2));
+    CHECK(secp256k1_fe_set_hex(&fe2, c64));
+    CHECK(secp256k1_fe_equal_var(&fe, &fe2));
+    secp256k1_fe_from_storage(&fe2, &fes);
+    CHECK(secp256k1_fe_equal_var(&fe, &fe2));
+    /* Check conversion from fe. */
+    secp256k1_fe_get_b32(b322, &fe);
+    CHECK(memcmp(b322, b32, 32) == 0);
+    secp256k1_fe_get_hex(c642, &fe);
+    CHECK(memcmp(c642, c64, 64) == 0);
+    secp256k1_fe_to_storage(&fes2, &fe);
+    CHECK(memcmp(&fes2, &fes, sizeof(fes)) == 0);
+}
+
 void run_field_misc(void) {
     const unsigned char f32_5[32] = {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -1668,6 +1704,7 @@ int main(int argc, char **argv) {
     run_field_inv_var();
     run_field_inv_all_var();
     run_field_misc();
+    run_field_convert();
     run_sqr();
     run_sqrt();
 


### PR DESCRIPTION
Introduce packed data types for field and group elements, which are smaller, guaranteed to be normalized and non-infinite, and are comparable in memory.

This speeds up signing around 1-2%, and verification around 0.1-0.2%, and reduces memory footprint.