### PR TITLE
secp256k1_ecdsa_sign: document the low S values

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -115,6 +115,10 @@ extern const secp256k1_nonce_function_t secp256k1_nonce_function_default;
  *  In/Out:  siglen: pointer to an int with the length of sig, which will be updated
  *                   to contain the actual signature length (<=72).
  * Requires starting using SECP256K1_START_SIGN.
+ *
+ * Unlike the standard ECDSA signing algorithm, this function is guaranteed to
+ * only generate signatures where the S value is less than or equal to the order
+ * of the group divided by 2.  The motivation is explained in BIP 0062.
  */
 int secp256k1_ecdsa_sign(
   const unsigned char *msg32,


### PR DESCRIPTION
Hello.  I am working on a Ruby binding for libsecp256k1.  When I was writing a test for `secp256k1_ecdsa_sign`, I was surprised that the signature it produced was different from the signature produced by my pure-Ruby ECDSA implementation, even though I had passed the same arguments to both.  I looked into it and I determined that the difference was caused by these lines in libsecp256k1, which force the S value to be in the lower 50% of its range:

https://github.com/bitcoin/secp256k1/blob/e84e761915e7882badcb611c40bb1c17b22d99eb/src/ecdsa_impl.h#L201-205

This pull request which adds documentation to the `secp256k1_ecdsa_sign` function explaining the low S values.  For people using the library for Bitcoin, I think this is an important guarantee to have on the signature, so it should be documented and we (anyone developing the library) should commit to it.  For people using the library for other purposes, or comparing it to other implementations, the low S values might be surprising since it makes this library behave differently from the standard ECDSA signing algorithm.

In general, my understanding is that ECDSA is defined by [SEC1](http://www.secg.org/sec1-v2.pdf), so if this library behaves differently from SEC1 then we should document that difference and explain the motivation for it.  Does that sound good?  Or is there some other standard you refer to?