### PR TITLE
secp256k1_ecdsa_sign:  Added a warning about an infinite loop.

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -115,6 +115,11 @@ extern const secp256k1_nonce_function_t secp256k1_nonce_function_default;
  *  In/Out:  siglen: pointer to an int with the length of sig, which will be updated
  *                   to contain the actual signature length (<=72).
  * Requires starting using SECP256K1_START_SIGN.
+ *
+ * If msg32 and seckey are all zeros, and noncefp always returns 1, then this
+ * function will never terminate.  A secret key that is all zeros is considered
+ * invalid, so you can avoid this issue if you validate seckey using
+ * secp256k1_ec_seckey_verify beforehand.
  */
 int secp256k1_ecdsa_sign(
   const unsigned char *msg32,
@@ -134,7 +139,9 @@ int secp256k1_ecdsa_sign(
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  *  Out:     sig:    pointer to a 64-byte array where the signature will be placed (cannot be NULL)
  *           recid:  pointer to an int, which will be updated to contain the recovery id (can be NULL)
- * Requires starting using SECP256K1_START_SIGN.
+ *
+ * Please see the documentation of secp256k1_ecdsa_sign because it has warnings
+ * that also apply to this function.
  */
 int secp256k1_ecdsa_sign_compact(
   const unsigned char *msg32,


### PR DESCRIPTION
Hello.  I was playing around with my Ruby binding for libsecp256k1 today, and I was surprised when I accidentally caused an infinite loop by calling `secp256k1_ecdsa_sign`.  I thought there should at least be a warning in the header file for this, so this pull request is my attempt to write such a warning.

Secret keys that are all zero are considered to be invalid by `secp256k1_ec_seckey_verify`. The documentation for the `seckey` argument to `secp256k1_ecdsa_sign` does say that the secret key is "assumed to be valid", so the caller would have to be in violation of that rule for the infinite loop to happen.  Still, I think there should at least be a warning.

Maybe we should go further though: In an application that allows untrusted user input to be used for the secret key and message hash, this infinite loop could be used in a denial of service attack.  One of the goals of the library is to be difficult to use insecurely.  Should we take steps to prevent this infinite loop from happening, like implementing a special check to see if both msg32 and seckey are 0, or a having a parameter for the maximum number of nonce-generation attempts before terminating?