### PR TITLE
BUG: array bounds overflow

### DIFF
--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -46,7 +46,7 @@ static void secp256k1_ecmult_gen_start(void) {
 
     /* Construct a group element with no known corresponding scalar (nothing up my sleeve). */
     {
-        static const unsigned char nums_b32[32] = "The scalar for this x is unknown";
+        static const unsigned char nums_b32[32] = "The scalar for the x is unknown";
         secp256k1_fe_t nums_x;
         secp256k1_ge_t nums_ge;
         VERIFY_CHECK(secp256k1_fe_set_b32(&nums_x, nums_b32));


### PR DESCRIPTION
A value of type "const char [33]" cannot be used to initialize an entity of type "const unsigned char [32]"
(C string ends \0 symbol)