### PR TITLE
initialize variable

### DIFF
--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -111,6 +111,7 @@ static void secp256k1_ecmult_gen(secp256k1_gej_t *r, const secp256k1_scalar_t *g
     secp256k1_ge_storage_t adds;
     int bits;
     int i, j;
+    memset(&adds, 0, sizeof(adds));
     secp256k1_gej_set_infinity(r);
     add.infinity = 0;
     for (j = 0; j < 64; j++) {


### PR DESCRIPTION
Without this, clang's static analyzer finds:
```
./src/field_5x52_impl.h:425:24: warning: The left operand of '&' is a garbage value
    r->n[0] = (r->n[0] & mask0) | (a->n[0] & mask1);
```