### PR TITLE
Expose ability to deep-copy a context

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -59,6 +59,14 @@ secp256k1_context_t* secp256k1_context_create(
   int flags
 ) SECP256K1_WARN_UNUSED_RESULT;
 
+/** Copies a secp256k1 context object.
+ *  Returns: a newly created context object.
+ *  In:      ctx: an existing context to copy
+ */
+secp256k1_context_t* secp256k1_context_clone(
+  const secp256k1_context_t* ctx
+) SECP256K1_WARN_UNUSED_RESULT;
+
 /** Destroy a secp256k1 context object.
  *  The context pointer may not be used afterwards.
  */

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -20,6 +20,8 @@ typedef struct {
 
 static void secp256k1_ecmult_context_init(secp256k1_ecmult_context_t *ctx);
 static void secp256k1_ecmult_context_build(secp256k1_ecmult_context_t *ctx);
+static void secp256k1_ecmult_context_clone(secp256k1_ecmult_context_t *dst,
+                                           const secp256k1_ecmult_context_t *src);
 static void secp256k1_ecmult_context_clear(secp256k1_ecmult_context_t *ctx);
 static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context_t *ctx);
 

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -28,6 +28,8 @@ typedef struct {
 
 static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context_t* ctx);
 static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context_t* ctx);
+static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context_t *dst,
+                                               const secp256k1_ecmult_gen_context_t* src);
 static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context_t* ctx);
 static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context_t* ctx);
 

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -80,6 +80,16 @@ static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_cont
     return ctx->prec != NULL;
 }
 
+static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context_t *dst,
+                                               const secp256k1_ecmult_gen_context_t *src) {
+    if (src->prec == NULL) {
+        dst->prec = NULL;
+    } else {
+        dst->prec = (secp256k1_ge_storage_t (*)[64][16])checked_malloc(sizeof(*dst->prec));
+        memcpy(dst->prec, src->prec, sizeof(*dst->prec));
+    }
+}
+
 static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context_t *ctx) {
     free(ctx->prec);
     ctx->prec = NULL;

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -131,6 +131,26 @@ static void secp256k1_ecmult_context_build(secp256k1_ecmult_context_t *ctx) {
 #endif
 }
 
+static void secp256k1_ecmult_context_clone(secp256k1_ecmult_context_t *dst,
+                                           const secp256k1_ecmult_context_t *src) {
+    if (src->pre_g == NULL) {
+        dst->pre_g = NULL;
+    } else {
+        size_t size = sizeof((*dst->pre_g)[0]) * ECMULT_TABLE_SIZE(WINDOW_G);
+        dst->pre_g = (secp256k1_ge_storage_t (*)[])checked_malloc(size);
+        memcpy(dst->pre_g, src->pre_g, size);
+    }
+#ifdef USE_ENDOMORPHISM
+    if (src->pre_g_128 == NULL) {
+        dst->pre_g_128 = NULL;
+    } else {
+        size_t size = sizeof((*dst->pre_g_128)[0]) * ECMULT_TABLE_SIZE(WINDOW_G);
+        dst->pre_g_128 = (secp256k1_ge_storage_t (*)[])checked_malloc(size);
+        memcpy(dst->pre_g_128, src->pre_g_128, size);
+    }
+#endif
+}
+
 static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context_t *ctx) {
     return ctx->pre_g != NULL;
 }

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -40,6 +40,13 @@ secp256k1_context_t* secp256k1_context_create(int flags) {
     return ret;
 }
 
+secp256k1_context_t* secp256k1_context_clone(const secp256k1_context_t* ctx) {
+    secp256k1_context_t* ret = (secp256k1_context_t*)checked_malloc(sizeof(secp256k1_context_t));
+    secp256k1_ecmult_context_clone(&ret->ecmult_ctx, &ctx->ecmult_ctx);
+    secp256k1_ecmult_gen_context_clone(&ret->ecmult_gen_ctx, &ctx->ecmult_gen_ctx);
+    return ret;
+}
+
 void secp256k1_context_destroy(secp256k1_context_t* ctx) {
     secp256k1_ecmult_context_clear(&ctx->ecmult_ctx);
     secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);


### PR DESCRIPTION
For the Rust bindings (and likely for binding to other languages which hide memory management from the user) I need to be able to deep-copy a secp256k1 context. This exposes a `secp256k1_context_clone` function which serves this purpose.
