### PR TITLE
Fix memory leak in context unit test

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -142,6 +142,12 @@ void run_context_tests(void) {
     /* try verifying */
     CHECK(secp256k1_ecdsa_sig_verify(&vrfy->ecmult_ctx, &sig, &pub, &msg));
     CHECK(secp256k1_ecdsa_sig_verify(&both->ecmult_ctx, &sig, &pub, &msg));
+
+    /* cleanup */
+    secp256k1_context_destroy(none);
+    secp256k1_context_destroy(sign);
+    secp256k1_context_destroy(vrfy);
+    secp256k1_context_destroy(both);
 }
 
 /***** HASH TESTS *****/


### PR DESCRIPTION
Before fix, `valgrind ./tests 1` outputs
  ==21959==     in use at exit: 2,228,288 bytes in 8 blocks

after:
  ==23974==     in use at exit: 0 bytes in 0 blocks