### PR TITLE
travis: update to new build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
         apt:
           packages:
             - gcc-multilib
+            - libgmp-dev:i386
     - compiler: clang
       env: HOST=i686-linux-gnu
       addons:
@@ -49,6 +50,7 @@ matrix:
         apt:
           packages:
             - gcc-multilib
+            - libgmp-dev:i386
 before_script: ./autogen.sh
 script:
  - if [ -n "$HOST" ]; then export USE_HOST="--host=$HOST"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: c
+sudo: false
+addons:
+  apt:
+    packages: libgmp-dev
 compiler:
   - clang
   - gcc
-install:
-  - sudo apt-get install -qq libssl-dev
-  - if [ "$BIGNUM" = "gmp" -o "$BIGNUM" = "auto" ]; then sudo apt-get install --no-install-recommends --no-upgrade -qq libgmp-dev; fi
-  - if [ -n "$EXTRAPACKAGES" ]; then sudo apt-get update && sudo apt-get install --no-install-recommends --no-upgrade $EXTRAPACKAGES; fi
 env:
   global:
-    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  ASM=no  BUILD=check  EXTRAFLAGS= HOST= EXTRAPACKAGES=
+    - FIELD=auto  BIGNUM=auto  SCALAR=auto  ENDOMORPHISM=no  ASM=no  BUILD=check  EXTRAFLAGS= HOST=
   matrix:
     - SCALAR=32bit
     - SCALAR=64bit
@@ -22,8 +22,33 @@ env:
     - BIGNUM=no       ENDOMORPHISM=yes
     - BUILD=distcheck
     - EXTRAFLAGS=CFLAGS=-DDETERMINISTIC
-    - HOST=i686-linux-gnu EXTRAPACKAGES="gcc-multilib"
-    - HOST=i686-linux-gnu EXTRAPACKAGES="gcc-multilib" ENDOMORPHISM=yes
+matrix:
+  fast_finish: true
+  include:
+    - compiler: clang
+      env: HOST=i686-linux-gnu ENDOMORPHISM=yes
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - compiler: clang
+      env: HOST=i686-linux-gnu
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - compiler: gcc
+      env: HOST=i686-linux-gnu ENDOMORPHISM=yes
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    - compiler: gcc
+      env: HOST=i686-linux-gnu
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
 before_script: ./autogen.sh
 script:
  - if [ -n "$HOST" ]; then export USE_HOST="--host=$HOST"; fi


### PR DESCRIPTION
See here for the reasoning:
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
    
Quick version: these changes remove our use of sudo so that we can move to the container-based
builds. This yields quicker builds and less reliance on the old infrastructure. It looks to be ~30%-50% quicker, though it's hard to tell because there's so much variance.

Since we can't use sudo, we now have to handle packages in the build-matrix rather than as part of the build step.

The second commit is pretty much unrelated, I just noticed that there was a gap in testing here.