### PR TITLE
Correct secp256k1_gej_add_ge

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -958,11 +958,17 @@ void ge_equals_gej(const secp256k1_ge_t *a, const secp256k1_gej_t *b) {
 
 void test_ge(void) {
     int i, i1;
+#ifdef USE_ENDOMORPHISM
+    int runs = 6;
+#else
     int runs = 4;
+#endif
     /* Points: (infinity, p1, p1, -p1, -p1, p2, p2, -p2, -p2, p3, p3, -p3, -p3, p4, p4, -p4, -p4).
      * The second in each pair of identical points uses a random Z coordinate in the Jacobian form.
      * All magnitudes are randomized.
      * All 17*17 combinations of points are added to eachother, using all applicable methods.
+     *
+     * When the endomorphism code is compiled in, p5 = lambda*p1 and p6 = lambda^2*p1 are added as well.
      */
     secp256k1_ge_t *ge = (secp256k1_ge_t *)malloc(sizeof(secp256k1_ge_t) * (1 + 4 * runs));
     secp256k1_gej_t *gej = (secp256k1_gej_t *)malloc(sizeof(secp256k1_gej_t) * (1 + 4 * runs));
@@ -977,6 +983,14 @@ void test_ge(void) {
         int j;
         secp256k1_ge_t g;
         random_group_element_test(&g);
+#ifdef USE_ENDOMORPHISM
+        if (i >= runs - 2) {
+            secp256k1_ge_mul_lambda(&g, &ge[1]);
+        }
+        if (i >= runs - 1) {
+            secp256k1_ge_mul_lambda(&g, &g);
+        }
+#endif
         ge[1 + 4 * i] = g;
         ge[2 + 4 * i] = g;
         secp256k1_ge_neg(&ge[3 + 4 * i], &g);

--- a/src/tests.c
+++ b/src/tests.c
@@ -1160,11 +1160,79 @@ void test_ge(void) {
     free(zinv);
 }
 
+void test_add_neg_y_diff_x(void) {
+    /* The point of this test is to check that we can add two points
+     * whose y-coordinates are negatives of each other but whose x
+     * coordinates differ. If the x-coordinates were the same, these
+     * points would be negatives of each other and their sum is
+     * infinity. This is cool because it "covers up" any degeneracy
+     * in the addition algorithm that would cause the xy coordinates
+     * of the sum to be wrong (since infinity has no xy coordinates).
+     * HOWEVER, if the x-coordinates are different, infinity is the
+     * wrong answer, and such degeneracies are exposed. This is the
+     * root of https://github.com/bitcoin/secp256k1/issues/257 which
+     * this test is a regression test for.
+     *
+     * These points were generated in sage as
+     * # secp256k1 params
+     * F = FiniteField (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F)
+     * C = EllipticCurve ([F (0), F (7)])
+     * G = C.lift_x(0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798)
+     * N = FiniteField(G.order())
+     *
+     * # endomorphism values (lambda is 1^{1/3} in N, beta is 1^{1/3} in F)
+     * x = polygen(N)
+     * lam  = (1 - x^3).roots()[1][0]
+     *
+     * # random "bad pair"
+     * P = C.random_element()
+     * Q = -int(lam) * P
+     * print "    P: %x %x" % P.xy()
+     * print "    Q: %x %x" % Q.xy()
+     * print "P + Q: %x %x" % (P + Q).xy()
+     */
+    secp256k1_gej_t aj = SECP256K1_GEJ_CONST(
+        0x8d24cd95, 0x0a355af1, 0x3c543505, 0x44238d30,
+        0x0643d79f, 0x05a59614, 0x2f8ec030, 0xd58977cb,
+        0x001e337a, 0x38093dcd, 0x6c0f386d, 0x0b1293a8,
+        0x4d72c879, 0xd7681924, 0x44e6d2f3, 0x9190117d
+    );
+    secp256k1_gej_t bj = SECP256K1_GEJ_CONST(
+        0xc7b74206, 0x1f788cd9, 0xabd0937d, 0x164a0d86,
+        0x95f6ff75, 0xf19a4ce9, 0xd013bd7b, 0xbf92d2a7,
+        0xffe1cc85, 0xc7f6c232, 0x93f0c792, 0xf4ed6c57,
+        0xb28d3786, 0x2897e6db, 0xbb192d0b, 0x6e6feab2
+    );
+    secp256k1_gej_t sumj = SECP256K1_GEJ_CONST(
+        0x671a63c0, 0x3efdad4c, 0x389a7798, 0x24356027,
+        0xb3d69010, 0x278625c3, 0x5c86d390, 0x184a8f7a,
+        0x5f6409c2, 0x2ce01f2b, 0x511fd375, 0x25071d08,
+        0xda651801, 0x70e95caf, 0x8f0d893c, 0xbed8fbbe
+    );
+    secp256k1_ge_t b;
+    secp256k1_gej_t resj;
+    secp256k1_ge_t res;
+    secp256k1_ge_set_gej(&b, &bj);
+
+    secp256k1_gej_add_var(&resj, &aj, &bj, NULL);
+    secp256k1_ge_set_gej(&res, &resj);
+    ge_equals_gej(&res, &sumj);
+
+    secp256k1_gej_add_ge(&resj, &aj, &b);
+    secp256k1_ge_set_gej(&res, &resj);
+    ge_equals_gej(&res, &sumj);
+
+    secp256k1_gej_add_ge_var(&resj, &aj, &b, NULL);
+    secp256k1_ge_set_gej(&res, &resj);
+    ge_equals_gej(&res, &sumj);
+}
+
 void run_ge(void) {
     int i;
     for (i = 0; i < count * 32; i++) {
         test_ge();
     }
+    test_add_neg_y_diff_x();
 }
 
 /***** ECMULT TESTS *****/


### PR DESCRIPTION
Fixes #257 by computing both double and add, and cmov'ing the correct result.

This is a simple and complete solution, but it has a significant performance impact (18% slowdown for signing). More efficient solutions can come later.