### PR TITLE
Add secp256k1_ec_pubkey_compress()

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -260,10 +260,27 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
   int compressed
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
+/** Compress a public key.
+ * In:     ctx:       pointer to a context object (cannot be NULL)
+ *         pubkeyin:  pointer to a 33-byte or 65-byte public key (cannot be NULL)
+ * Out:    pubkeyout: pointer to a 33-byte array to put the compressed public key (cannot be NULL)
+ *                    May alias pubkeyin.
+ *         pubkeylen: pointer to the size of the public key pointed to by pubkeyin (cannot be NULL)
+ *                    It will be updated to reflect the size of the public key in pubkeyout.
+ * Returns: 0: pubkeyin was invalid
+ *          1: pubkeyin was valid, and pubkeyout is its compressed version
+ */
+SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_compress(
+  const secp256k1_context_t* ctx,
+  const unsigned char *pubkeyin,
+  unsigned char *pubkeyout,
+  int *pubkeylen
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
+
 /** Decompress a public key.
  * In:     ctx:       pointer to a context object (cannot be NULL)
- * In:     pubkeyin:  pointer to a 33-byte or 65-byte public key (cannot be NULL)
- * In/Out: pubkeyout: pointer to a 65-byte array to put the decompressed public key (cannot be NULL)
+ *         pubkeyin:  pointer to a 33-byte or 65-byte public key (cannot be NULL)
+ * Out:    pubkeyout: pointer to a 65-byte array to put the decompressed public key (cannot be NULL)
  *                    May alias pubkeyin.
  *         pubkeylen: pointer to the size of the public key pointed to by pubkeyin (cannot be NULL)
  *                    It will be updated to reflect the size of the public key in pubkeyout.

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -285,6 +285,21 @@ int secp256k1_ec_pubkey_decompress(const secp256k1_context_t* ctx, const unsigne
     return ret;
 }
 
+int secp256k1_ec_pubkey_compress(const secp256k1_context_t* ctx, const unsigned char *pubkeyin, unsigned char *pubkeyout, int *pubkeylen) {
+    secp256k1_ge_t p;
+    int ret = 0;
+    DEBUG_CHECK(pubkeyin != NULL);
+    DEBUG_CHECK(pubkeyout != NULL);
+    DEBUG_CHECK(pubkeylen != NULL);
+    (void)ctx;
+
+    if (secp256k1_eckey_pubkey_parse(&p, pubkeyin, *pubkeylen)) {
+        ret = secp256k1_eckey_pubkey_serialize(&p, pubkeyout, pubkeylen, 1);
+    }
+
+    return ret;
+}
+
 int secp256k1_ec_privkey_tweak_add(const secp256k1_context_t* ctx, unsigned char *seckey, const unsigned char *tweak) {
     secp256k1_scalar_t term;
     secp256k1_scalar_t sec;

--- a/src/tests.c
+++ b/src/tests.c
@@ -1512,14 +1512,22 @@ void test_ecdsa_end_to_end(void) {
     CHECK(secp256k1_ec_pubkey_create(ctx, pubkey, &pubkeylen, privkey, (secp256k1_rand32() & 3) != 0) == 1);
     if (secp256k1_rand32() & 1) {
         unsigned char pubkey2[65] = {0};
-        int pubkey2len = pubkeylen;
+        unsigned char pubkey3RE[33] = {0};
+        int pubkey2len = pubkeylen, pubkey3len = pubkeylen;
+
         /* Decompress into a new array */
         CHECK(secp256k1_ec_pubkey_decompress(ctx, pubkey, pubkey2, &pubkey2len));
+
+        /* Compress into a new array */
+        CHECK(secp256k1_ec_pubkey_compress(ctx, pubkey, pubkey3RE, &pubkey3len));
+
         /* Check that the key was changed iff it was originally compressed */
         if (pubkeylen == 65) {
-            CHECK(memcmp(pubkey, pubkey2, 65) == 0);
+            CHECK(memcmp(pubkey, pubkey2, 65) == 0);         /* Values should be the same */
+            CHECK(memcmp(pubkey3RE, pubkey, 33) != 0);       /* Means it should have been compressed */
         } else {
-            CHECK(memcmp(pubkey, pubkey2, 65) != 0);
+            CHECK(memcmp(pubkey, pubkey2, 65) != 0);         /* Should have been decompressed */
+            CHECK(memcmp(pubkey3RE, pubkey, 33) == 0);       /* Therefore compressed key should equal initial pubkey */
         }
         /* Decompress in place */
         CHECK(secp256k1_ec_pubkey_decompress(ctx, pubkey, pubkey, &pubkeylen));


### PR DESCRIPTION
Added general function to reserialize a public key, and added secp256k1_ec_pubkey_compress() after seeing https://github.com/bitcoin/secp256k1/issues/259