### PR TITLE
Improve performance of _ecmult_wnaf

### DIFF
--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -229,7 +229,7 @@ void bench_ecmult_wnaf(void* arg) {
     bench_inv_t *data = (bench_inv_t*)arg;
 
     for (i = 0; i < 20000; i++) {
-        secp256k1_ecmult_wnaf(data->wnaf, &data->scalar_x, WINDOW_A);
+        secp256k1_ecmult_wnaf(data->wnaf, 256, &data->scalar_x, WINDOW_A);
         secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -1374,7 +1374,7 @@ void test_wnaf(const secp256k1_scalar_t *number, int w) {
     int bits;
     secp256k1_scalar_set_int(&x, 0);
     secp256k1_scalar_set_int(&two, 2);
-    bits = secp256k1_ecmult_wnaf(wnaf, number, w);
+    bits = secp256k1_ecmult_wnaf(wnaf, 256, number, w);
     CHECK(bits <= 256);
     for (i = bits-1; i >= 0; i--) {
         int v = wnaf[i];


### PR DESCRIPTION
- Track carry explicitly instead of adding to scalar
- Branch-free code for carry calculations

Gives ~0.6% improvement for bench_verify (64bit, endo=yes)