### PR TITLE
Add missing casts to SECP256K1_FE_CONST_INNER

### DIFF
--- a/src/field_10x26.h
+++ b/src/field_10x26.h
@@ -21,15 +21,15 @@ typedef struct {
 /* Unpacks a constant into a overlapping multi-limbed FE element. */
 #define SECP256K1_FE_CONST_INNER(d7, d6, d5, d4, d3, d2, d1, d0) { \
     (d0) & 0x3FFFFFFUL, \
-    ((d0) >> 26) | ((d1) & 0xFFFFFUL) << 6, \
-    ((d1) >> 20) | ((d2) & 0x3FFFUL) << 12, \
-    ((d2) >> 14) | ((d3) & 0xFFUL) << 18, \
-    ((d3) >> 8) | ((d4) & 0x3) << 24, \
-    ((d4) >> 2) & 0x3FFFFFFUL, \
-    ((d4) >> 28) | ((d5) & 0x3FFFFFUL) << 4, \
-    ((d5) >> 22) | ((d6) & 0xFFFF) << 10, \
-    ((d6) >> 16) | ((d7) & 0x3FF) << 16, \
-    ((d7) >> 10) \
+    (((uint32_t)d0) >> 26) | ((uint32_t)(d1) & 0xFFFFFUL) << 6, \
+    (((uint32_t)d1) >> 20) | ((uint32_t)(d2) & 0x3FFFUL) << 12, \
+    (((uint32_t)d2) >> 14) | ((uint32_t)(d3) & 0xFFUL) << 18, \
+    (((uint32_t)d3) >> 8) | ((uint32_t)(d4) & 0x3UL) << 24, \
+    (((uint32_t)d4) >> 2) & 0x3FFFFFFUL, \
+    (((uint32_t)d4) >> 28) | ((uint32_t)(d5) & 0x3FFFFFUL) << 4, \
+    (((uint32_t)d5) >> 22) | ((uint32_t)(d6) & 0xFFFFUL) << 10, \
+    (((uint32_t)d6) >> 16) | ((uint32_t)(d7) & 0x3FFUL) << 16, \
+    (((uint32_t)d7) >> 10) \
 }
 
 #ifdef VERIFY

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -21,10 +21,10 @@ typedef struct {
 /* Unpacks a constant into a overlapping multi-limbed FE element. */
 #define SECP256K1_FE_CONST_INNER(d7, d6, d5, d4, d3, d2, d1, d0) { \
     (d0) | ((uint64_t)(d1) & 0xFFFFFUL) << 32, \
-    ((d1) >> 20) | ((uint64_t)(d2)) << 12 | ((uint64_t)(d3) & 0xFFUL) << 44, \
-    ((d3) >> 8) | ((uint64_t)(d4) & 0xFFFFFFFUL) << 24, \
-    ((d4) >> 28) | ((uint64_t)(d5)) << 4 | ((uint64_t)(d6) & 0xFFFFUL) << 36, \
-    ((d6) >> 16) | ((uint64_t)(d7)) << 16 \
+    ((uint64_t)(d1) >> 20) | ((uint64_t)(d2)) << 12 | ((uint64_t)(d3) & 0xFFUL) << 44, \
+    ((uint64_t)(d3) >> 8) | ((uint64_t)(d4) & 0xFFFFFFFUL) << 24, \
+    ((uint64_t)(d4) >> 28) | ((uint64_t)(d5)) << 4 | ((uint64_t)(d6) & 0xFFFFUL) << 36, \
+    ((uint64_t)(d6) >> 16) | ((uint64_t)(d7)) << 16 \
 }
 
 #ifdef VERIFY


### PR DESCRIPTION
This corrects for compilers where `int` is too small to allow constants to be shifted as much as they are in the `SECP256K1_FE_CONST_INNER` macro.

On my x86_64 system this change results in a bit-for-bit identical test binary, with both 32- and 64-bit field and scalars.