### PR TITLE
Make ecmult static precomputation default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - FIELD=32bit     ENDOMORPHISM=yes
     - BIGNUM=no
     - BIGNUM=no       ENDOMORPHISM=yes
-    - BIGNUM=no       STATICPRECOMPUTATION=yes
+    - BIGNUM=no       STATICPRECOMPUTATION=no
     - BUILD=distcheck
     - EXTRAFLAGS=CFLAGS=-DDETERMINISTIC
 matrix:

--- a/configure.ac
+++ b/configure.ac
@@ -98,9 +98,9 @@ AC_ARG_ENABLE(endomorphism,
     [use_endomorphism=no])
     
 AC_ARG_ENABLE(ecmult_static_precomputation,
-    AS_HELP_STRING([--enable-ecmult-static-precomputation],[enable precomputed ecmult table for signing (default is no)]),
+    AS_HELP_STRING([--enable-ecmult-static-precomputation],[enable precomputed ecmult table for signing (default is yes)]),
     [use_ecmult_static_precomputation=$enableval],
-    [use_ecmult_static_precomputation=no])
+    [use_ecmult_static_precomputation=yes])
 
 AC_ARG_WITH([field], [AS_HELP_STRING([--with-field=64bit|32bit|auto],
 [Specify Field Implementation. Default is auto])],[req_field=$withval], [req_field=auto])


### PR DESCRIPTION
There are very few cases where a 64 KiB smaller binary weighs up against reduced start up time and better reuse of RAM.