### PR TITLE
Update configure.ac to make it build on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,8 @@ if test "x$CFLAGS" = "x"; then
   CFLAGS="-O3 -g"
 fi
 
+AM_PROG_CC_C_O
+
 AC_PROG_CC_C89
 if test x"$ac_cv_prog_cc_c89" = x"no"; then
   AC_MSG_ERROR([c89 compiler support required])


### PR DESCRIPTION
This update is to make libsecp256k1 build on OpenBSD (more specifically OpenBSD 5.7 with Autotools 2.69).

Without the "AM_PROG_CC_C_O" line in configure.ac, ./autogen.sh crashes with "Makefile.am: C objects in subdir but `AM_PROG_CC_C_O' not in `configure.ac'\nautoreconf-2.69: automake failed with exit status: 1".