### PR TITLE
Gen context make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,7 +86,8 @@ gen_%.o: src/gen_%.c
 gen_context$(BUILD_EXEEXT): $(gen_context_OBJECTS)
 	$(CC_FOR_BUILD) $^ -o $@
 
-BUILT_SOURCES = src/ecmult_static_context.h
+$(libsecp256k1_la_OBJECTS): src/ecmult_static_context.h
+$(tests_OBJECTS): src/ecmult_static_context.h
 
 src/ecmult_static_context.h: gen_context
 	./gen_context

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,20 +79,20 @@ CPPFLAGS_FOR_BUILD +=-I$(top_srcdir)/
 CFLAGS_FOR_BUILD += -Wall -Wextra -Wno-unused-function
 
 gen_context_OBJECTS = gen_context.o
-
+gen_context_BIN = gen_context$(BUILD_EXEEXT)
 gen_%.o: src/gen_%.c
 	$(CC_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(CFLAGS_FOR_BUILD) -c $< -o $@
 
-gen_context$(BUILD_EXEEXT): $(gen_context_OBJECTS)
+$(gen_context_BIN): $(gen_context_OBJECTS)
 	$(CC_FOR_BUILD) $^ -o $@
 
 $(libsecp256k1_la_OBJECTS): src/ecmult_static_context.h
 $(tests_OBJECTS): src/ecmult_static_context.h
 
-src/ecmult_static_context.h: gen_context
-	./gen_context
+src/ecmult_static_context.h: $(gen_context_BIN)
+	./$(gen_context_BIN)
 
-CLEANFILES = gen_context src/ecmult_static_context.h
+CLEANFILES = $(gen_context_BIN) src/ecmult_static_context.h
 endif
 
 EXTRA_DIST = autogen.sh src/gen_context.c src/basic-config.h


### PR DESCRIPTION
BUILT_SOURCES simply forces the header to be built first when no target is specified.

Use real dependencies instead. This fixes builds with dependency tracking disabled where a real target is specified.

Also fixup the build so that "gen_context.exe" is used for windows.