### PR TITLE
[API BREAK] Remove _t in types due to being POSIX-reserved

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -40,7 +40,7 @@ extern "C" {
  *  Regarding randomization, either do it once at creation time (in which case
  *  you do not need any locking for the other calls), or use a read-write lock.
  */
-typedef struct secp256k1_context_struct secp256k1_context_t;
+typedef struct secp256k1_context_struct secp256k1_context;
 
 /** Opaque data structure that holds a parsed and valid public key.
  *
@@ -55,7 +55,7 @@ typedef struct secp256k1_context_struct secp256k1_context_t;
  */
 typedef struct {
     unsigned char data[64];
-} secp256k1_pubkey_t;
+} secp256k1_pubkey;
 
 /** Opaque data structured that holds a parsed ECDSA signature.
  *
@@ -71,7 +71,7 @@ typedef struct {
  */
 typedef struct {
     unsigned char data[64];
-} secp256k1_ecdsa_signature_t;
+} secp256k1_ecdsa_signature;
 
 /** A pointer to a function to deterministically generate a nonce.
  *
@@ -89,7 +89,7 @@ typedef struct {
  * Except for test cases, this function should compute some cryptographic hash of
  * the message, the algorithm, the key and the attempt.
  */
-typedef int (*secp256k1_nonce_function_t)(
+typedef int (*secp256k1_nonce_function)(
     unsigned char *nonce32,
     const unsigned char *msg32,
     const unsigned char *key32,
@@ -145,7 +145,7 @@ typedef int (*secp256k1_nonce_function_t)(
  *  Returns: a newly created context object.
  *  In:      flags: which parts of the context to initialize.
  */
-secp256k1_context_t* secp256k1_context_create(
+secp256k1_context* secp256k1_context_create(
     unsigned int flags
 ) SECP256K1_WARN_UNUSED_RESULT;
 
@@ -154,8 +154,8 @@ secp256k1_context_t* secp256k1_context_create(
  *  Returns: a newly created context object.
  *  Args:    ctx: an existing context to copy (cannot be NULL)
  */
-secp256k1_context_t* secp256k1_context_clone(
-    const secp256k1_context_t* ctx
+secp256k1_context* secp256k1_context_clone(
+    const secp256k1_context* ctx
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_WARN_UNUSED_RESULT;
 
 /** Destroy a secp256k1 context object.
@@ -164,7 +164,7 @@ secp256k1_context_t* secp256k1_context_clone(
  *  Args:   ctx: an existing context to destroy (cannot be NULL)
  */
 void secp256k1_context_destroy(
-    secp256k1_context_t* ctx
+    secp256k1_context* ctx
 );
 
 /** Set a callback function to be called when an illegal argument is passed to
@@ -188,7 +188,7 @@ void secp256k1_context_destroy(
  *        data: the opaque pointer to pass to fun above.
  */
 void secp256k1_context_set_illegal_callback(
-    secp256k1_context_t* ctx,
+    secp256k1_context* ctx,
     void (*fun)(const char* message, void* data),
     const void* data
 ) SECP256K1_ARG_NONNULL(1);
@@ -210,7 +210,7 @@ void secp256k1_context_set_illegal_callback(
  *        data: the opaque pointer to pass to fun above.
  */
 void secp256k1_context_set_error_callback(
-    secp256k1_context_t* ctx,
+    secp256k1_context* ctx,
     void (*fun)(const char* message, void* data),
     const void* data
 ) SECP256K1_ARG_NONNULL(1);
@@ -230,8 +230,8 @@ void secp256k1_context_set_error_callback(
  *  byte 0x06 or 0x07) format public keys.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
-    const secp256k1_context_t* ctx,
-    secp256k1_pubkey_t* pubkey,
+    const secp256k1_context* ctx,
+    secp256k1_pubkey* pubkey,
     const unsigned char *input,
     size_t inputlen
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
@@ -244,16 +244,16 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
  *                    compressed==1) byte array to place the serialized key in.
  *        outputlen:  a pointer to an integer which will contain the serialized
  *                    size.
- *  In:   pubkey:     a pointer to a secp256k1_pubkey_t containing an initialized
+ *  In:   pubkey:     a pointer to a secp256k1_pubkey containing an initialized
  *                    public key.
  *        flags:      SECP256K1_EC_COMPRESSED if serialization should be in
  *                    compressed format.
  */
 int secp256k1_ec_pubkey_serialize(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     unsigned char *output,
     size_t *outputlen,
-    const secp256k1_pubkey_t* pubkey,
+    const secp256k1_pubkey* pubkey,
     unsigned int flags
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
@@ -268,8 +268,8 @@ int secp256k1_ec_pubkey_serialize(
  *  Note that this function also supports some violations of DER and even BER.
  */
 int secp256k1_ecdsa_signature_parse_der(
-    const secp256k1_context_t* ctx,
-    secp256k1_ecdsa_signature_t* sig,
+    const secp256k1_context* ctx,
+    secp256k1_ecdsa_signature* sig,
     const unsigned char *input,
     size_t inputlen
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
@@ -286,10 +286,10 @@ int secp256k1_ecdsa_signature_parse_der(
  *  In:     sig:       a pointer to an initialized signature object
  */
 int secp256k1_ecdsa_signature_serialize_der(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     unsigned char *output,
     size_t *outputlen,
-    const secp256k1_ecdsa_signature_t* sig
+    const secp256k1_ecdsa_signature* sig
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** Verify an ECDSA signature.
@@ -302,20 +302,20 @@ int secp256k1_ecdsa_signature_serialize_der(
  *           pubkey:    pointer to an initialized public key to verify with (cannot be NULL)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
-    const secp256k1_context_t* ctx,
-    const secp256k1_ecdsa_signature_t *sig,
+    const secp256k1_context* ctx,
+    const secp256k1_ecdsa_signature *sig,
     const unsigned char *msg32,
-    const secp256k1_pubkey_t *pubkey
+    const secp256k1_pubkey *pubkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** An implementation of RFC6979 (using HMAC-SHA256) as nonce generation function.
  * If a data pointer is passed, it is assumed to be a pointer to 32 bytes of
  * extra entropy.
  */
-extern const secp256k1_nonce_function_t secp256k1_nonce_function_rfc6979;
+extern const secp256k1_nonce_function secp256k1_nonce_function_rfc6979;
 
 /** A default safe nonce generation function (currently equal to secp256k1_nonce_function_rfc6979). */
-extern const secp256k1_nonce_function_t secp256k1_nonce_function_default;
+extern const secp256k1_nonce_function secp256k1_nonce_function_default;
 
 /** Create an ECDSA signature.
  *
@@ -356,11 +356,11 @@ extern const secp256k1_nonce_function_t secp256k1_nonce_function_default;
  * be taken when this property is required for an application.
  */
 int secp256k1_ecdsa_sign(
-    const secp256k1_context_t* ctx,
-    secp256k1_ecdsa_signature_t *sig,
+    const secp256k1_context* ctx,
+    secp256k1_ecdsa_signature *sig,
     const unsigned char *msg32,
     const unsigned char *seckey,
-    secp256k1_nonce_function_t noncefp,
+    secp256k1_nonce_function noncefp,
     const void *ndata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
@@ -372,7 +372,7 @@ int secp256k1_ecdsa_sign(
  *  In:      seckey: pointer to a 32-byte secret key (cannot be NULL)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     const unsigned char *seckey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
 
@@ -385,8 +385,8 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(
  *  In:     seckey:     pointer to a 32-byte private key (cannot be NULL)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
-    const secp256k1_context_t* ctx,
-    secp256k1_pubkey_t *pubkey,
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *pubkey,
     const unsigned char *seckey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
@@ -411,7 +411,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
  *  guaranteed to be parsable by secp256k1_ec_privkey_import.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_export(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     unsigned char *privkey,
     size_t *privkeylen,
     const unsigned char *seckey,
@@ -433,7 +433,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_export(
  * key.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_import(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *privkey,
     size_t privkeylen
@@ -449,7 +449,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_import(
  * In:      tweak:  pointer to a 32-byte tweak.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
@@ -465,8 +465,8 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
  * In:      tweak:  pointer to a 32-byte tweak.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
-    const secp256k1_context_t* ctx,
-    secp256k1_pubkey_t *pubkey,
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *pubkey,
     const unsigned char *tweak
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
@@ -478,7 +478,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
  * In:     tweak:  pointer to a 32-byte tweak.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
@@ -492,8 +492,8 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
  * In:      tweak:  pointer to a 32-byte tweak.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
-    const secp256k1_context_t* ctx,
-    secp256k1_pubkey_t *pubkey,
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *pubkey,
     const unsigned char *tweak
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
@@ -504,7 +504,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
  *  In:      seed32:    pointer to a 32-byte random seed (NULL resets to initial state)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
-    secp256k1_context_t* ctx,
+    secp256k1_context* ctx,
     const unsigned char *seed32
 ) SECP256K1_ARG_NONNULL(1);
 
@@ -520,9 +520,9 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
  *  uncompressed format is needed.
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
-    const secp256k1_context_t* ctx,
-    secp256k1_pubkey_t *out,
-    const secp256k1_pubkey_t * const * ins,
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *out,
+    const secp256k1_pubkey * const * ins,
     int n
 ) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 

--- a/include/secp256k1_ecdh.h
+++ b/include/secp256k1_ecdh.h
@@ -17,9 +17,9 @@ extern "C" {
  *           scalar:   a 32-byte scalar with which to multiply the point
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh(
-  const secp256k1_context_t* ctx,
+  const secp256k1_context* ctx,
   unsigned char *result,
-  const secp256k1_pubkey_t *point,
+  const secp256k1_pubkey *point,
   const unsigned char *scalar
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 

--- a/include/secp256k1_recovery.h
+++ b/include/secp256k1_recovery.h
@@ -23,7 +23,7 @@ extern "C" {
  */
 typedef struct {
     unsigned char data[65];
-} secp256k1_ecdsa_recoverable_signature_t;
+} secp256k1_ecdsa_recoverable_signature;
 
 /** Parse a compact ECDSA signature (64 bytes + recovery id).
  *
@@ -34,8 +34,8 @@ typedef struct {
  *        recid:   the recovery id (0, 1, 2 or 3)
  */
 int secp256k1_ecdsa_recoverable_signature_parse_compact(
-    const secp256k1_context_t* ctx,
-    secp256k1_ecdsa_recoverable_signature_t* sig,
+    const secp256k1_context* ctx,
+    secp256k1_ecdsa_recoverable_signature* sig,
     const unsigned char *input64,
     int recid
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
@@ -47,9 +47,9 @@ int secp256k1_ecdsa_recoverable_signature_parse_compact(
  *  In:  sigin:  a pointer to a recoverable signature (cannot be NULL).
  */
 int secp256k1_ecdsa_recoverable_signature_convert(
-    const secp256k1_context_t* ctx,
-    secp256k1_ecdsa_signature_t* sig,
-    const secp256k1_ecdsa_recoverable_signature_t* sigin
+    const secp256k1_context* ctx,
+    secp256k1_ecdsa_signature* sig,
+    const secp256k1_ecdsa_recoverable_signature* sigin
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 /** Serialize an ECDSA signature in compact format (64 bytes + recovery id).
@@ -61,10 +61,10 @@ int secp256k1_ecdsa_recoverable_signature_convert(
  *  In:   sig:      a pointer to an initialized signature object (cannot be NULL)
  */
 int secp256k1_ecdsa_recoverable_signature_serialize_compact(
-    const secp256k1_context_t* ctx,
+    const secp256k1_context* ctx,
     unsigned char *output64,
     int *recid,
-    const secp256k1_ecdsa_recoverable_signature_t* sig
+    const secp256k1_ecdsa_recoverable_signature* sig
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(4);
 
 /** Create a recoverable ECDSA signature.
@@ -79,11 +79,11 @@ int secp256k1_ecdsa_recoverable_signature_serialize_compact(
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  */
 int secp256k1_ecdsa_sign_recoverable(
-    const secp256k1_context_t* ctx,
-    secp256k1_ecdsa_recoverable_signature_t *sig,
+    const secp256k1_context* ctx,
+    secp256k1_ecdsa_recoverable_signature *sig,
     const unsigned char *msg32,
     const unsigned char *seckey,
-    secp256k1_nonce_function_t noncefp,
+    secp256k1_nonce_function noncefp,
     const void *ndata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
@@ -97,9 +97,9 @@ int secp256k1_ecdsa_sign_recoverable(
  *           msg32:      the 32-byte message hash assumed to be signed (cannot be NULL)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover(
-    const secp256k1_context_t* ctx,
-    secp256k1_pubkey_t *pubkey,
-    const secp256k1_ecdsa_recoverable_signature_t *sig,
+    const secp256k1_context* ctx,
+    secp256k1_pubkey *pubkey,
+    const secp256k1_ecdsa_recoverable_signature *sig,
     const unsigned char *msg32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 

--- a/include/secp256k1_schnorr.h
+++ b/include/secp256k1_schnorr.h
@@ -25,11 +25,11 @@ extern "C" {
  *                   function (can be NULL)
  */
 int secp256k1_schnorr_sign(
-  const secp256k1_context_t* ctx,
+  const secp256k1_context* ctx,
   unsigned char *sig64,
   const unsigned char *msg32,
   const unsigned char *seckey,
-  secp256k1_nonce_function_t noncefp,
+  secp256k1_nonce_function noncefp,
   const void *ndata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
@@ -42,10 +42,10 @@ int secp256k1_schnorr_sign(
  *           pubkey:    the public key to verify with (cannot be NULL)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
-  const secp256k1_context_t* ctx,
+  const secp256k1_context* ctx,
   const unsigned char *sig64,
   const unsigned char *msg32,
-  const secp256k1_pubkey_t *pubkey
+  const secp256k1_pubkey *pubkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
 /** Recover an EC public key from a Schnorr signature created using
@@ -62,8 +62,8 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
  *                       be NULL)
  */
 int secp256k1_schnorr_recover(
-  const secp256k1_context_t* ctx,
-  secp256k1_pubkey_t *pubkey,
+  const secp256k1_context* ctx,
+  secp256k1_pubkey *pubkey,
   const unsigned char *sig64,
   const unsigned char *msg32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
@@ -87,12 +87,12 @@ int secp256k1_schnorr_recover(
  *  Do not use the output as a private/public key pair for signing/validation.
  */
 int secp256k1_schnorr_generate_nonce_pair(
-  const secp256k1_context_t* ctx,
-  secp256k1_pubkey_t *pubnonce,
+  const secp256k1_context* ctx,
+  secp256k1_pubkey *pubnonce,
   unsigned char *privnonce32,
   const unsigned char *msg32,
   const unsigned char *sec32,
-  secp256k1_nonce_function_t noncefp,
+  secp256k1_nonce_function noncefp,
   const void* noncedata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(6) SECP256K1_ARG_NONNULL(7);
 
@@ -139,11 +139,11 @@ int secp256k1_schnorr_generate_nonce_pair(
  *  by calling the function again (they are commutative and associative).
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_sign(
-  const secp256k1_context_t* ctx,
+  const secp256k1_context* ctx,
   unsigned char *sig64,
   const unsigned char *msg32,
   const unsigned char *sec32,
-  const secp256k1_pubkey_t *pubnonce_others,
+  const secp256k1_pubkey *pubnonce_others,
   const unsigned char *secnonce32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
 
@@ -160,7 +160,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_sign(
  *         n:        the number of signatures to combine (at least 1)
  */
 SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_combine(
-  const secp256k1_context_t* ctx,
+  const secp256k1_context* ctx,
   unsigned char *sig64,
   const unsigned char * const * sig64sin,
   int n

--- a/src/bench_ecdh.c
+++ b/src/bench_ecdh.c
@@ -12,8 +12,8 @@
 #include "bench.h"
 
 typedef struct {
-    secp256k1_context_t *ctx;
-    secp256k1_pubkey_t point;
+    secp256k1_context *ctx;
+    secp256k1_pubkey point;
     unsigned char scalar[32];
 } bench_ecdh_t;
 

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -19,10 +19,10 @@
 #include "secp256k1.c"
 
 typedef struct {
-    secp256k1_scalar_t scalar_x, scalar_y;
-    secp256k1_fe_t fe_x, fe_y;
-    secp256k1_ge_t ge_x, ge_y;
-    secp256k1_gej_t gej_x, gej_y;
+    secp256k1_scalar scalar_x, scalar_y;
+    secp256k1_fe fe_x, fe_y;
+    secp256k1_ge ge_x, ge_y;
+    secp256k1_gej gej_x, gej_y;
     unsigned char data[64];
     int wnaf[256];
 } bench_inv_t;
@@ -98,7 +98,7 @@ void bench_scalar_split(void* arg) {
     bench_inv_t *data = (bench_inv_t*)arg;
 
     for (i = 0; i < 20000; i++) {
-        secp256k1_scalar_t l, r;
+        secp256k1_scalar l, r;
         secp256k1_scalar_split_lambda(&l, &r, &data->scalar_x);
         secp256k1_scalar_add(&data->scalar_x, &data->scalar_x, &data->scalar_y);
     }

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -10,7 +10,7 @@
 #include "bench.h"
 
 typedef struct {
-    secp256k1_context_t *ctx;
+    secp256k1_context *ctx;
     unsigned char msg[32];
     unsigned char sig[64];
 } bench_recover_t;
@@ -18,13 +18,13 @@ typedef struct {
 void bench_recover(void* arg) {
     int i;
     bench_recover_t *data = (bench_recover_t*)arg;
-    secp256k1_pubkey_t pubkey;
+    secp256k1_pubkey pubkey;
     unsigned char pubkeyc[33];
 
     for (i = 0; i < 20000; i++) {
         int j;
         size_t pubkeylen = 33;
-        secp256k1_ecdsa_recoverable_signature_t sig;
+        secp256k1_ecdsa_recoverable_signature sig;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(data->ctx, &sig, data->sig, i % 2));
         CHECK(secp256k1_ecdsa_recover(data->ctx, &pubkey, &sig, data->msg));
         CHECK(secp256k1_ec_pubkey_serialize(data->ctx, pubkeyc, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED));

--- a/src/bench_schnorr_verify.c
+++ b/src/bench_schnorr_verify.c
@@ -20,7 +20,7 @@ typedef struct {
 } benchmark_schnorr_sig_t;
 
 typedef struct {
-    secp256k1_context_t *ctx;
+    secp256k1_context *ctx;
     unsigned char msg[32];
     benchmark_schnorr_sig_t sigs[64];
     int numsigs;
@@ -34,7 +34,7 @@ static void benchmark_schnorr_init(void* arg) {
         data->msg[i] = 1 + i;
     }
     for (k = 0; k < data->numsigs; k++) {
-        secp256k1_pubkey_t pubkey;
+        secp256k1_pubkey pubkey;
         for (i = 0; i < 32; i++) {
             data->sigs[k].key[i] = 33 + i + k;
         }
@@ -50,7 +50,7 @@ static void benchmark_schnorr_verify(void* arg) {
     benchmark_schnorr_verify_t* data = (benchmark_schnorr_verify_t*)arg;
 
     for (i = 0; i < 20000 / data->numsigs; i++) {
-        secp256k1_pubkey_t pubkey;
+        secp256k1_pubkey pubkey;
         data->sigs[0].sig[(i >> 8) % 64] ^= (i & 0xFF);
         CHECK(secp256k1_ec_pubkey_parse(data->ctx, &pubkey, data->sigs[0].pubkey, data->sigs[0].pubkeylen));
         CHECK(secp256k1_schnorr_verify(data->ctx, data->sigs[0].sig, data->msg, &pubkey) == ((i & 0xFF) == 0));

--- a/src/bench_sign.c
+++ b/src/bench_sign.c
@@ -9,7 +9,7 @@
 #include "bench.h"
 
 typedef struct {
-    secp256k1_context_t* ctx;
+    secp256k1_context* ctx;
     unsigned char msg[32];
     unsigned char key[32];
 } bench_sign_t;
@@ -34,7 +34,7 @@ static void bench_sign(void* arg) {
     for (i = 0; i < 20000; i++) {
         size_t siglen = 74;
         int j;
-        secp256k1_ecdsa_signature_t signature;
+        secp256k1_ecdsa_signature signature;
         CHECK(secp256k1_ecdsa_sign(data->ctx, &signature, data->msg, data->key, NULL, NULL));
         CHECK(secp256k1_ecdsa_signature_serialize_der(data->ctx, sig, &siglen, &signature));
         for (j = 0; j < 32; j++) {

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -12,7 +12,7 @@
 #include "bench.h"
 
 typedef struct {
-    secp256k1_context_t *ctx;
+    secp256k1_context *ctx;
     unsigned char msg[32];
     unsigned char key[32];
     unsigned char sig[72];
@@ -26,8 +26,8 @@ static void benchmark_verify(void* arg) {
     benchmark_verify_t* data = (benchmark_verify_t*)arg;
 
     for (i = 0; i < 20000; i++) {
-        secp256k1_pubkey_t pubkey;
-        secp256k1_ecdsa_signature_t sig;
+        secp256k1_pubkey pubkey;
+        secp256k1_ecdsa_signature sig;
         data->sig[data->siglen - 1] ^= (i & 0xFF);
         data->sig[data->siglen - 2] ^= ((i >> 8) & 0xFF);
         data->sig[data->siglen - 3] ^= ((i >> 16) & 0xFF);
@@ -42,8 +42,8 @@ static void benchmark_verify(void* arg) {
 
 int main(void) {
     int i;
-    secp256k1_pubkey_t pubkey;
-    secp256k1_ecdsa_signature_t sig;
+    secp256k1_pubkey pubkey;
+    secp256k1_ecdsa_signature sig;
     benchmark_verify_t data;
 
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -13,10 +13,10 @@
 #include "group.h"
 #include "ecmult.h"
 
-static int secp256k1_ecdsa_sig_parse(secp256k1_scalar_t *r, secp256k1_scalar_t *s, const unsigned char *sig, size_t size);
-static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar_t *r, const secp256k1_scalar_t *s);
-static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context_t *ctx, const secp256k1_scalar_t* r, const secp256k1_scalar_t* s, const secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message);
-static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context_t *ctx, secp256k1_scalar_t* r, secp256k1_scalar_t* s, const secp256k1_scalar_t *seckey, const secp256k1_scalar_t *message, const secp256k1_scalar_t *nonce, int *recid);
-static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context_t *ctx, const secp256k1_scalar_t* r, const secp256k1_scalar_t* s, secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message, int recid);
+static int secp256k1_ecdsa_sig_parse(secp256k1_scalar *r, secp256k1_scalar *s, const unsigned char *sig, size_t size);
+static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar *r, const secp256k1_scalar *s);
+static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context *ctx, const secp256k1_scalar* r, const secp256k1_scalar* s, const secp256k1_ge *pubkey, const secp256k1_scalar *message);
+static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar* r, secp256k1_scalar* s, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid);
+static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context *ctx, const secp256k1_scalar* r, const secp256k1_scalar* s, secp256k1_ge *pubkey, const secp256k1_scalar *message, int recid);
 
 #endif

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -28,7 +28,7 @@
  *  sage: '%x' % (EllipticCurve ([F (a), F (b)]).order())
  *   'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141'
  */
-static const secp256k1_fe_t secp256k1_ecdsa_const_order_as_fe = SECP256K1_FE_CONST(
+static const secp256k1_fe secp256k1_ecdsa_const_order_as_fe = SECP256K1_FE_CONST(
     0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFEUL,
     0xBAAEDCE6UL, 0xAF48A03BUL, 0xBFD25E8CUL, 0xD0364141UL
 );
@@ -42,11 +42,11 @@ static const secp256k1_fe_t secp256k1_ecdsa_const_order_as_fe = SECP256K1_FE_CON
  *  sage: '%x' % (p - EllipticCurve ([F (a), F (b)]).order())
  *   '14551231950b75fc4402da1722fc9baee'
  */
-static const secp256k1_fe_t secp256k1_ecdsa_const_p_minus_order = SECP256K1_FE_CONST(
+static const secp256k1_fe secp256k1_ecdsa_const_p_minus_order = SECP256K1_FE_CONST(
     0, 0, 0, 1, 0x45512319UL, 0x50B75FC4UL, 0x402DA172UL, 0x2FC9BAEEUL
 );
 
-static int secp256k1_ecdsa_sig_parse(secp256k1_scalar_t *rr, secp256k1_scalar_t *rs, const unsigned char *sig, size_t size) {
+static int secp256k1_ecdsa_sig_parse(secp256k1_scalar *rr, secp256k1_scalar *rs, const unsigned char *sig, size_t size) {
     unsigned char ra[32] = {0}, sa[32] = {0};
     const unsigned char *rp;
     const unsigned char *sp;
@@ -109,7 +109,7 @@ static int secp256k1_ecdsa_sig_parse(secp256k1_scalar_t *rr, secp256k1_scalar_t 
     return 1;
 }
 
-static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar_t* ar, const secp256k1_scalar_t* as) {
+static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar* ar, const secp256k1_scalar* as) {
     unsigned char r[33] = {0}, s[33] = {0};
     unsigned char *rp = r, *sp = s;
     size_t lenR = 33, lenS = 33;
@@ -133,12 +133,12 @@ static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const
     return 1;
 }
 
-static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context_t *ctx, const secp256k1_scalar_t *sigr, const secp256k1_scalar_t *sigs, const secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message) {
+static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context *ctx, const secp256k1_scalar *sigr, const secp256k1_scalar *sigs, const secp256k1_ge *pubkey, const secp256k1_scalar *message) {
     unsigned char c[32];
-    secp256k1_scalar_t sn, u1, u2;
-    secp256k1_fe_t xr;
-    secp256k1_gej_t pubkeyj;
-    secp256k1_gej_t pr;
+    secp256k1_scalar sn, u1, u2;
+    secp256k1_fe xr;
+    secp256k1_gej pubkeyj;
+    secp256k1_gej pr;
 
     if (secp256k1_scalar_is_zero(sigr) || secp256k1_scalar_is_zero(sigs)) {
         return 0;
@@ -187,13 +187,13 @@ static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context_t *ctx, con
     return 0;
 }
 
-static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context_t *ctx, const secp256k1_scalar_t *sigr, const secp256k1_scalar_t* sigs, secp256k1_ge_t *pubkey, const secp256k1_scalar_t *message, int recid) {
+static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context *ctx, const secp256k1_scalar *sigr, const secp256k1_scalar* sigs, secp256k1_ge *pubkey, const secp256k1_scalar *message, int recid) {
     unsigned char brx[32];
-    secp256k1_fe_t fx;
-    secp256k1_ge_t x;
-    secp256k1_gej_t xj;
-    secp256k1_scalar_t rn, u1, u2;
-    secp256k1_gej_t qj;
+    secp256k1_fe fx;
+    secp256k1_ge x;
+    secp256k1_gej xj;
+    secp256k1_scalar rn, u1, u2;
+    secp256k1_gej qj;
 
     if (secp256k1_scalar_is_zero(sigr) || secp256k1_scalar_is_zero(sigs)) {
         return 0;
@@ -220,11 +220,11 @@ static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context_t *ctx, co
     return !secp256k1_gej_is_infinity(&qj);
 }
 
-static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context_t *ctx, secp256k1_scalar_t *sigr, secp256k1_scalar_t *sigs, const secp256k1_scalar_t *seckey, const secp256k1_scalar_t *message, const secp256k1_scalar_t *nonce, int *recid) {
+static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid) {
     unsigned char b[32];
-    secp256k1_gej_t rp;
-    secp256k1_ge_t r;
-    secp256k1_scalar_t n;
+    secp256k1_gej rp;
+    secp256k1_ge r;
+    secp256k1_scalar n;
     int overflow = 0;
 
     secp256k1_ecmult_gen(ctx, &rp, nonce);

--- a/src/eckey.h
+++ b/src/eckey.h
@@ -14,15 +14,15 @@
 #include "ecmult.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_pubkey_parse(secp256k1_ge_t *elem, const unsigned char *pub, size_t size);
-static int secp256k1_eckey_pubkey_serialize(secp256k1_ge_t *elem, unsigned char *pub, size_t *size, unsigned int flags);
+static int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size);
+static int secp256k1_eckey_pubkey_serialize(secp256k1_ge *elem, unsigned char *pub, size_t *size, unsigned int flags);
 
-static int secp256k1_eckey_privkey_parse(secp256k1_scalar_t *key, const unsigned char *privkey, size_t privkeylen);
-static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context_t *ctx, unsigned char *privkey, size_t *privkeylen, const secp256k1_scalar_t *key, unsigned int flags);
+static int secp256k1_eckey_privkey_parse(secp256k1_scalar *key, const unsigned char *privkey, size_t privkeylen);
+static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context *ctx, unsigned char *privkey, size_t *privkeylen, const secp256k1_scalar *key, unsigned int flags);
 
-static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar_t *key, const secp256k1_scalar_t *tweak);
-static int secp256k1_eckey_pubkey_tweak_add(const secp256k1_ecmult_context_t *ctx, secp256k1_ge_t *key, const secp256k1_scalar_t *tweak);
-static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar_t *key, const secp256k1_scalar_t *tweak);
-static int secp256k1_eckey_pubkey_tweak_mul(const secp256k1_ecmult_context_t *ctx, secp256k1_ge_t *key, const secp256k1_scalar_t *tweak);
+static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak);
+static int secp256k1_eckey_pubkey_tweak_add(const secp256k1_ecmult_context *ctx, secp256k1_ge *key, const secp256k1_scalar *tweak);
+static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak);
+static int secp256k1_eckey_pubkey_tweak_mul(const secp256k1_ecmult_context *ctx, secp256k1_ge *key, const secp256k1_scalar *tweak);
 
 #endif

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -14,12 +14,12 @@
 #include "group.h"
 #include "ecmult_gen.h"
 
-static int secp256k1_eckey_pubkey_parse(secp256k1_ge_t *elem, const unsigned char *pub, size_t size) {
+static int secp256k1_eckey_pubkey_parse(secp256k1_ge *elem, const unsigned char *pub, size_t size) {
     if (size == 33 && (pub[0] == 0x02 || pub[0] == 0x03)) {
-        secp256k1_fe_t x;
+        secp256k1_fe x;
         return secp256k1_fe_set_b32(&x, pub+1) && secp256k1_ge_set_xo_var(elem, &x, pub[0] == 0x03);
     } else if (size == 65 && (pub[0] == 0x04 || pub[0] == 0x06 || pub[0] == 0x07)) {
-        secp256k1_fe_t x, y;
+        secp256k1_fe x, y;
         if (!secp256k1_fe_set_b32(&x, pub+1) || !secp256k1_fe_set_b32(&y, pub+33)) {
             return 0;
         }
@@ -33,7 +33,7 @@ static int secp256k1_eckey_pubkey_parse(secp256k1_ge_t *elem, const unsigned cha
     }
 }
 
-static int secp256k1_eckey_pubkey_serialize(secp256k1_ge_t *elem, unsigned char *pub, size_t *size, unsigned int flags) {
+static int secp256k1_eckey_pubkey_serialize(secp256k1_ge *elem, unsigned char *pub, size_t *size, unsigned int flags) {
     if (secp256k1_ge_is_infinity(elem)) {
         return 0;
     }
@@ -51,7 +51,7 @@ static int secp256k1_eckey_pubkey_serialize(secp256k1_ge_t *elem, unsigned char 
     return 1;
 }
 
-static int secp256k1_eckey_privkey_parse(secp256k1_scalar_t *key, const unsigned char *privkey, size_t privkeylen) {
+static int secp256k1_eckey_privkey_parse(secp256k1_scalar *key, const unsigned char *privkey, size_t privkeylen) {
     unsigned char c[32] = {0};
     const unsigned char *end = privkey + privkeylen;
     int lenb = 0;
@@ -94,9 +94,9 @@ static int secp256k1_eckey_privkey_parse(secp256k1_scalar_t *key, const unsigned
     return !overflow;
 }
 
-static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context_t *ctx, unsigned char *privkey, size_t *privkeylen, const secp256k1_scalar_t *key, unsigned int flags) {
-    secp256k1_gej_t rp;
-    secp256k1_ge_t r;
+static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context *ctx, unsigned char *privkey, size_t *privkeylen, const secp256k1_scalar *key, unsigned int flags) {
+    secp256k1_gej rp;
+    secp256k1_ge r;
     size_t pubkeylen = 0;
     secp256k1_ecmult_gen(ctx, &rp, key);
     secp256k1_ge_set_gej(&r, &rp);
@@ -154,7 +154,7 @@ static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context_
     return 1;
 }
 
-static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar_t *key, const secp256k1_scalar_t *tweak) {
+static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
     secp256k1_scalar_add(key, key, tweak);
     if (secp256k1_scalar_is_zero(key)) {
         return 0;
@@ -162,9 +162,9 @@ static int secp256k1_eckey_privkey_tweak_add(secp256k1_scalar_t *key, const secp
     return 1;
 }
 
-static int secp256k1_eckey_pubkey_tweak_add(const secp256k1_ecmult_context_t *ctx, secp256k1_ge_t *key, const secp256k1_scalar_t *tweak) {
-    secp256k1_gej_t pt;
-    secp256k1_scalar_t one;
+static int secp256k1_eckey_pubkey_tweak_add(const secp256k1_ecmult_context *ctx, secp256k1_ge *key, const secp256k1_scalar *tweak) {
+    secp256k1_gej pt;
+    secp256k1_scalar one;
     secp256k1_gej_set_ge(&pt, key);
     secp256k1_scalar_set_int(&one, 1);
     secp256k1_ecmult(ctx, &pt, &pt, &one, tweak);
@@ -176,7 +176,7 @@ static int secp256k1_eckey_pubkey_tweak_add(const secp256k1_ecmult_context_t *ct
     return 1;
 }
 
-static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar_t *key, const secp256k1_scalar_t *tweak) {
+static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar *key, const secp256k1_scalar *tweak) {
     if (secp256k1_scalar_is_zero(tweak)) {
         return 0;
     }
@@ -185,9 +185,9 @@ static int secp256k1_eckey_privkey_tweak_mul(secp256k1_scalar_t *key, const secp
     return 1;
 }
 
-static int secp256k1_eckey_pubkey_tweak_mul(const secp256k1_ecmult_context_t *ctx, secp256k1_ge_t *key, const secp256k1_scalar_t *tweak) {
-    secp256k1_scalar_t zero;
-    secp256k1_gej_t pt;
+static int secp256k1_eckey_pubkey_tweak_mul(const secp256k1_ecmult_context *ctx, secp256k1_ge *key, const secp256k1_scalar *tweak) {
+    secp256k1_scalar zero;
+    secp256k1_gej pt;
     if (secp256k1_scalar_is_zero(tweak)) {
         return 0;
     }

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -12,20 +12,20 @@
 
 typedef struct {
     /* For accelerating the computation of a*P + b*G: */
-    secp256k1_ge_storage_t (*pre_g)[];    /* odd multiples of the generator */
+    secp256k1_ge_storage (*pre_g)[];    /* odd multiples of the generator */
 #ifdef USE_ENDOMORPHISM
-    secp256k1_ge_storage_t (*pre_g_128)[]; /* odd multiples of 2^128*generator */
+    secp256k1_ge_storage (*pre_g_128)[]; /* odd multiples of 2^128*generator */
 #endif
-} secp256k1_ecmult_context_t;
+} secp256k1_ecmult_context;
 
-static void secp256k1_ecmult_context_init(secp256k1_ecmult_context_t *ctx);
-static void secp256k1_ecmult_context_build(secp256k1_ecmult_context_t *ctx, const callback_t *cb);
-static void secp256k1_ecmult_context_clone(secp256k1_ecmult_context_t *dst,
-                                           const secp256k1_ecmult_context_t *src, const callback_t *cb);
-static void secp256k1_ecmult_context_clear(secp256k1_ecmult_context_t *ctx);
-static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context_t *ctx);
+static void secp256k1_ecmult_context_init(secp256k1_ecmult_context *ctx);
+static void secp256k1_ecmult_context_build(secp256k1_ecmult_context *ctx, const secp256k1_callback *cb);
+static void secp256k1_ecmult_context_clone(secp256k1_ecmult_context *dst,
+                                           const secp256k1_ecmult_context *src, const secp256k1_callback *cb);
+static void secp256k1_ecmult_context_clear(secp256k1_ecmult_context *ctx);
+static int secp256k1_ecmult_context_is_built(const secp256k1_ecmult_context *ctx);
 
 /** Double multiply: R = na*A + ng*G */
-static void secp256k1_ecmult(const secp256k1_ecmult_context_t *ctx, secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_scalar_t *na, const secp256k1_scalar_t *ng);
+static void secp256k1_ecmult(const secp256k1_ecmult_context *ctx, secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_scalar *na, const secp256k1_scalar *ng);
 
 #endif

--- a/src/ecmult_const.h
+++ b/src/ecmult_const.h
@@ -10,6 +10,6 @@
 #include "scalar.h"
 #include "group.h"
 
-static void secp256k1_ecmult_const(secp256k1_gej_t *r, const secp256k1_ge_t *a, const secp256k1_scalar_t *q);
+static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, const secp256k1_scalar *q);
 
 #endif

--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -24,7 +24,7 @@
     int m; \
     int abs_n = (n) * (((n) > 0) * 2 - 1); \
     int idx_n = abs_n / 2; \
-    secp256k1_fe_t neg_y; \
+    secp256k1_fe neg_y; \
     VERIFY_CHECK(((n) & 1) == 1); \
     VERIFY_CHECK((n) >= -((1 << ((w)-1)) - 1)); \
     VERIFY_CHECK((n) <=  ((1 << ((w)-1)) - 1)); \
@@ -54,7 +54,7 @@
  *
  *  Numbers reference steps of `Algorithm SPA-resistant Width-w NAF with Odd Scalar` on pp. 335
  */
-static int secp256k1_wnaf_const(int *wnaf, secp256k1_scalar_t s, int w) {
+static int secp256k1_wnaf_const(int *wnaf, secp256k1_scalar s, int w) {
     int global_sign = 1;
     int skew = 0;
     int word = 0;
@@ -74,7 +74,7 @@ static int secp256k1_wnaf_const(int *wnaf, secp256k1_scalar_t s, int w) {
     /* We add 1 to even numbers, 2 to odd ones, noting that negation flips parity */
     int bit = flip ^ (s.d[0] & 1);
     /* We check for negative one, since adding 2 to it will cause an overflow */
-    secp256k1_scalar_t neg_s;
+    secp256k1_scalar neg_s;
     int not_neg_one;
     secp256k1_scalar_negate(&neg_s, &s);
     not_neg_one = !secp256k1_scalar_is_one(&neg_s);
@@ -120,24 +120,24 @@ static int secp256k1_wnaf_const(int *wnaf, secp256k1_scalar_t s, int w) {
 }
 
 
-static void secp256k1_ecmult_const(secp256k1_gej_t *r, const secp256k1_ge_t *a, const secp256k1_scalar_t *scalar) {
-    secp256k1_ge_t pre_a[ECMULT_TABLE_SIZE(WINDOW_A)];
-    secp256k1_ge_t tmpa;
-    secp256k1_fe_t Z;
+static void secp256k1_ecmult_const(secp256k1_gej *r, const secp256k1_ge *a, const secp256k1_scalar *scalar) {
+    secp256k1_ge pre_a[ECMULT_TABLE_SIZE(WINDOW_A)];
+    secp256k1_ge tmpa;
+    secp256k1_fe Z;
 
 #ifdef USE_ENDOMORPHISM
-    secp256k1_ge_t pre_a_lam[ECMULT_TABLE_SIZE(WINDOW_A)];
+    secp256k1_ge pre_a_lam[ECMULT_TABLE_SIZE(WINDOW_A)];
     int wnaf_1[1 + WNAF_SIZE(WINDOW_A - 1)];
     int wnaf_lam[1 + WNAF_SIZE(WINDOW_A - 1)];
     int skew_1;
     int skew_lam;
-    secp256k1_scalar_t q_1, q_lam;
+    secp256k1_scalar q_1, q_lam;
 #else
     int wnaf[1 + WNAF_SIZE(WINDOW_A - 1)];
 #endif
 
     int i;
-    secp256k1_scalar_t sc = *scalar;
+    secp256k1_scalar sc = *scalar;
 
     /* build wnaf representation for q. */
 #ifdef USE_ENDOMORPHISM
@@ -223,11 +223,11 @@ static void secp256k1_ecmult_const(secp256k1_gej_t *r, const secp256k1_ge_t *a, 
 #ifdef USE_ENDOMORPHISM
     {
         /* Correct for wNAF skew */
-        secp256k1_ge_t correction = *a;
-        secp256k1_ge_storage_t correction_1_stor;
-        secp256k1_ge_storage_t correction_lam_stor;
-        secp256k1_ge_storage_t a2_stor;
-        secp256k1_gej_t tmpj;
+        secp256k1_ge correction = *a;
+        secp256k1_ge_storage correction_1_stor;
+        secp256k1_ge_storage correction_lam_stor;
+        secp256k1_ge_storage a2_stor;
+        secp256k1_gej tmpj;
         secp256k1_gej_set_ge(&tmpj, &correction);
         secp256k1_gej_double_var(&tmpj, &tmpj, NULL);
         secp256k1_ge_set_gej(&correction, &tmpj);

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -23,21 +23,21 @@ typedef struct {
      * None of the resulting prec group elements have a known scalar, and neither do any of
      * the intermediate sums while computing a*G.
      */
-    secp256k1_ge_storage_t (*prec)[64][16]; /* prec[j][i] = 16^j * i * G + U_i */
-    secp256k1_scalar_t blind;
-    secp256k1_gej_t initial;
-} secp256k1_ecmult_gen_context_t;
+    secp256k1_ge_storage (*prec)[64][16]; /* prec[j][i] = 16^j * i * G + U_i */
+    secp256k1_scalar blind;
+    secp256k1_gej initial;
+} secp256k1_ecmult_gen_context;
 
-static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context_t* ctx);
-static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context_t* ctx, const callback_t* cb);
-static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context_t *dst,
-                                               const secp256k1_ecmult_gen_context_t* src, const callback_t* cb);
-static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context_t* ctx);
-static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context_t* ctx);
+static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context* ctx);
+static void secp256k1_ecmult_gen_context_build(secp256k1_ecmult_gen_context* ctx, const secp256k1_callback* cb);
+static void secp256k1_ecmult_gen_context_clone(secp256k1_ecmult_gen_context *dst,
+                                               const secp256k1_ecmult_gen_context* src, const secp256k1_callback* cb);
+static void secp256k1_ecmult_gen_context_clear(secp256k1_ecmult_gen_context* ctx);
+static int secp256k1_ecmult_gen_context_is_built(const secp256k1_ecmult_gen_context* ctx);
 
 /** Multiply with the generator: R = a*G */
-static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context_t* ctx, secp256k1_gej_t *r, const secp256k1_scalar_t *a);
+static void secp256k1_ecmult_gen(const secp256k1_ecmult_gen_context* ctx, secp256k1_gej *r, const secp256k1_scalar *a);
 
-static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context_t *ctx, const unsigned char *seed32);
+static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const unsigned char *seed32);
 
 #endif

--- a/src/field.h
+++ b/src/field.h
@@ -31,89 +31,89 @@
 #endif
 
 /** Normalize a field element. */
-static void secp256k1_fe_normalize(secp256k1_fe_t *r);
+static void secp256k1_fe_normalize(secp256k1_fe *r);
 
 /** Weakly normalize a field element: reduce it magnitude to 1, but don't fully normalize. */
-static void secp256k1_fe_normalize_weak(secp256k1_fe_t *r);
+static void secp256k1_fe_normalize_weak(secp256k1_fe *r);
 
 /** Normalize a field element, without constant-time guarantee. */
-static void secp256k1_fe_normalize_var(secp256k1_fe_t *r);
+static void secp256k1_fe_normalize_var(secp256k1_fe *r);
 
 /** Verify whether a field element represents zero i.e. would normalize to a zero value. The field
  *  implementation may optionally normalize the input, but this should not be relied upon. */
-static int secp256k1_fe_normalizes_to_zero(secp256k1_fe_t *r);
+static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r);
 
 /** Verify whether a field element represents zero i.e. would normalize to a zero value. The field
  *  implementation may optionally normalize the input, but this should not be relied upon. */
-static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe_t *r);
+static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r);
 
 /** Set a field element equal to a small integer. Resulting field element is normalized. */
-static void secp256k1_fe_set_int(secp256k1_fe_t *r, int a);
+static void secp256k1_fe_set_int(secp256k1_fe *r, int a);
 
 /** Verify whether a field element is zero. Requires the input to be normalized. */
-static int secp256k1_fe_is_zero(const secp256k1_fe_t *a);
+static int secp256k1_fe_is_zero(const secp256k1_fe *a);
 
 /** Check the "oddness" of a field element. Requires the input to be normalized. */
-static int secp256k1_fe_is_odd(const secp256k1_fe_t *a);
+static int secp256k1_fe_is_odd(const secp256k1_fe *a);
 
 /** Compare two field elements. Requires magnitude-1 inputs. */
-static int secp256k1_fe_equal_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b);
+static int secp256k1_fe_equal_var(const secp256k1_fe *a, const secp256k1_fe *b);
 
 /** Compare two field elements. Requires both inputs to be normalized */
-static int secp256k1_fe_cmp_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b);
+static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b);
 
 /** Set a field element equal to 32-byte big endian value. If successful, the resulting field element is normalized. */
-static int secp256k1_fe_set_b32(secp256k1_fe_t *r, const unsigned char *a);
+static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a);
 
 /** Convert a field element to a 32-byte big endian value. Requires the input to be normalized */
-static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe_t *a);
+static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe *a);
 
 /** Set a field element equal to the additive inverse of another. Takes a maximum magnitude of the input
  *  as an argument. The magnitude of the output is one higher. */
-static void secp256k1_fe_negate(secp256k1_fe_t *r, const secp256k1_fe_t *a, int m);
+static void secp256k1_fe_negate(secp256k1_fe *r, const secp256k1_fe *a, int m);
 
 /** Multiplies the passed field element with a small integer constant. Multiplies the magnitude by that
  *  small integer. */
-static void secp256k1_fe_mul_int(secp256k1_fe_t *r, int a);
+static void secp256k1_fe_mul_int(secp256k1_fe *r, int a);
 
 /** Adds a field element to another. The result has the sum of the inputs' magnitudes as magnitude. */
-static void secp256k1_fe_add(secp256k1_fe_t *r, const secp256k1_fe_t *a);
+static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Sets a field element to be the product of two others. Requires the inputs' magnitudes to be at most 8.
  *  The output magnitude is 1 (but not guaranteed to be normalized). */
-static void secp256k1_fe_mul(secp256k1_fe_t *r, const secp256k1_fe_t *a, const secp256k1_fe_t * SECP256K1_RESTRICT b);
+static void secp256k1_fe_mul(secp256k1_fe *r, const secp256k1_fe *a, const secp256k1_fe * SECP256K1_RESTRICT b);
 
 /** Sets a field element to be the square of another. Requires the input's magnitude to be at most 8.
  *  The output magnitude is 1 (but not guaranteed to be normalized). */
-static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a);
+static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Sets a field element to be the (modular) square root (if any exist) of another. Requires the
  *  input's magnitude to be at most 8. The output magnitude is 1 (but not guaranteed to be
  *  normalized). Return value indicates whether a square root was found. */
-static int secp256k1_fe_sqrt_var(secp256k1_fe_t *r, const secp256k1_fe_t *a);
+static int secp256k1_fe_sqrt_var(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Sets a field element to be the (modular) inverse of another. Requires the input's magnitude to be
  *  at most 8. The output magnitude is 1 (but not guaranteed to be normalized). */
-static void secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a);
+static void secp256k1_fe_inv(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Potentially faster version of secp256k1_fe_inv, without constant-time guarantee. */
-static void secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a);
+static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Calculate the (modular) inverses of a batch of field elements. Requires the inputs' magnitudes to be
  *  at most 8. The output magnitudes are 1 (but not guaranteed to be normalized). The inputs and
  *  outputs must not overlap in memory. */
-static void secp256k1_fe_inv_all_var(size_t len, secp256k1_fe_t *r, const secp256k1_fe_t *a);
+static void secp256k1_fe_inv_all_var(size_t len, secp256k1_fe *r, const secp256k1_fe *a);
 
 /** Convert a field element to the storage type. */
-static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_fe_t*);
+static void secp256k1_fe_to_storage(secp256k1_fe_storage *r, const secp256k1_fe*);
 
 /** Convert a field element back from the storage type. */
-static void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_storage_t*);
+static void secp256k1_fe_from_storage(secp256k1_fe *r, const secp256k1_fe_storage*);
 
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
-static void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag);
+static void secp256k1_fe_storage_cmov(secp256k1_fe_storage *r, const secp256k1_fe_storage *a, int flag);
 
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
-static void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag);
+static void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_fe *a, int flag);
 
 #endif

--- a/src/field_10x26.h
+++ b/src/field_10x26.h
@@ -16,7 +16,7 @@ typedef struct {
     int magnitude;
     int normalized;
 #endif
-} secp256k1_fe_t;
+} secp256k1_fe;
 
 /* Unpacks a constant into a overlapping multi-limbed FE element. */
 #define SECP256K1_FE_CONST_INNER(d7, d6, d5, d4, d3, d2, d1, d0) { \
@@ -40,7 +40,7 @@ typedef struct {
 
 typedef struct {
     uint32_t n[8];
-} secp256k1_fe_storage_t;
+} secp256k1_fe_storage;
 
 #define SECP256K1_FE_STORAGE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{ (d0), (d1), (d2), (d3), (d4), (d5), (d6), (d7) }}
 #define SECP256K1_FE_STORAGE_CONST_GET(d) d.n[7], d.n[6], d.n[5], d.n[4],d.n[3], d.n[2], d.n[1], d.n[0]

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -14,7 +14,7 @@
 #include "field.h"
 
 #ifdef VERIFY
-static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
+static void secp256k1_fe_verify(const secp256k1_fe *a) {
     const uint32_t *d = a->n;
     int m = a->normalized ? 1 : 2 * a->magnitude, r = 1;
     r &= (d[0] <= 0x3FFFFFFUL * m);
@@ -41,12 +41,12 @@ static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
     VERIFY_CHECK(r == 1);
 }
 #else
-static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
+static void secp256k1_fe_verify(const secp256k1_fe *a) {
     (void)a;
 }
 #endif
 
-static void secp256k1_fe_normalize(secp256k1_fe_t *r) {
+static void secp256k1_fe_normalize(secp256k1_fe *r) {
     uint32_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4],
              t5 = r->n[5], t6 = r->n[6], t7 = r->n[7], t8 = r->n[8], t9 = r->n[9];
 
@@ -101,7 +101,7 @@ static void secp256k1_fe_normalize(secp256k1_fe_t *r) {
 #endif
 }
 
-static void secp256k1_fe_normalize_weak(secp256k1_fe_t *r) {
+static void secp256k1_fe_normalize_weak(secp256k1_fe *r) {
     uint32_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4],
              t5 = r->n[5], t6 = r->n[6], t7 = r->n[7], t8 = r->n[8], t9 = r->n[9];
 
@@ -132,7 +132,7 @@ static void secp256k1_fe_normalize_weak(secp256k1_fe_t *r) {
 #endif
 }
 
-static void secp256k1_fe_normalize_var(secp256k1_fe_t *r) {
+static void secp256k1_fe_normalize_var(secp256k1_fe *r) {
     uint32_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4],
              t5 = r->n[5], t6 = r->n[6], t7 = r->n[7], t8 = r->n[8], t9 = r->n[9];
 
@@ -188,7 +188,7 @@ static void secp256k1_fe_normalize_var(secp256k1_fe_t *r) {
 #endif
 }
 
-static int secp256k1_fe_normalizes_to_zero(secp256k1_fe_t *r) {
+static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r) {
     uint32_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4],
              t5 = r->n[5], t6 = r->n[6], t7 = r->n[7], t8 = r->n[8], t9 = r->n[9];
 
@@ -217,7 +217,7 @@ static int secp256k1_fe_normalizes_to_zero(secp256k1_fe_t *r) {
     return (z0 == 0) | (z1 == 0x3FFFFFFUL);
 }
 
-static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe_t *r) {
+static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r) {
     uint32_t t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;
     uint32_t z0, z1;
     uint32_t x;
@@ -269,7 +269,7 @@ static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe_t *r) {
     return (z0 == 0) | (z1 == 0x3FFFFFFUL);
 }
 
-SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe_t *r, int a) {
+SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe *r, int a) {
     r->n[0] = a;
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = r->n[5] = r->n[6] = r->n[7] = r->n[8] = r->n[9] = 0;
 #ifdef VERIFY
@@ -279,7 +279,7 @@ SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe_t *r, int a) {
 #endif
 }
 
-SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe_t *a) {
+SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe *a) {
     const uint32_t *t = a->n;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
@@ -288,7 +288,7 @@ SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe_t *a) {
     return (t[0] | t[1] | t[2] | t[3] | t[4] | t[5] | t[6] | t[7] | t[8] | t[9]) == 0;
 }
 
-SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe_t *a) {
+SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe *a) {
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
     secp256k1_fe_verify(a);
@@ -296,7 +296,7 @@ SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe_t *a) {
     return a->n[0] & 1;
 }
 
-SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe_t *a) {
+SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
     int i;
 #ifdef VERIFY
     a->magnitude = 0;
@@ -307,7 +307,7 @@ SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe_t *a) {
     }
 }
 
-static int secp256k1_fe_cmp_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b) {
+static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     int i;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
@@ -326,7 +326,7 @@ static int secp256k1_fe_cmp_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b
     return 0;
 }
 
-static int secp256k1_fe_set_b32(secp256k1_fe_t *r, const unsigned char *a) {
+static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a) {
     int i;
     r->n[0] = r->n[1] = r->n[2] = r->n[3] = r->n[4] = 0;
     r->n[5] = r->n[6] = r->n[7] = r->n[8] = r->n[9] = 0;
@@ -350,7 +350,7 @@ static int secp256k1_fe_set_b32(secp256k1_fe_t *r, const unsigned char *a) {
 }
 
 /** Convert a field element to a 32-byte big endian value. Requires the input to be normalized */
-static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe_t *a) {
+static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe *a) {
     int i;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
@@ -368,7 +368,7 @@ static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe_t *a) {
     }
 }
 
-SECP256K1_INLINE static void secp256k1_fe_negate(secp256k1_fe_t *r, const secp256k1_fe_t *a, int m) {
+SECP256K1_INLINE static void secp256k1_fe_negate(secp256k1_fe *r, const secp256k1_fe *a, int m) {
 #ifdef VERIFY
     VERIFY_CHECK(a->magnitude <= m);
     secp256k1_fe_verify(a);
@@ -390,7 +390,7 @@ SECP256K1_INLINE static void secp256k1_fe_negate(secp256k1_fe_t *r, const secp25
 #endif
 }
 
-SECP256K1_INLINE static void secp256k1_fe_mul_int(secp256k1_fe_t *r, int a) {
+SECP256K1_INLINE static void secp256k1_fe_mul_int(secp256k1_fe *r, int a) {
     r->n[0] *= a;
     r->n[1] *= a;
     r->n[2] *= a;
@@ -408,7 +408,7 @@ SECP256K1_INLINE static void secp256k1_fe_mul_int(secp256k1_fe_t *r, int a) {
 #endif
 }
 
-SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
+SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_fe *a) {
 #ifdef VERIFY
     secp256k1_fe_verify(a);
 #endif
@@ -1039,7 +1039,7 @@ SECP256K1_INLINE static void secp256k1_fe_sqr_inner(uint32_t *r, const uint32_t 
 }
 
 
-static void secp256k1_fe_mul(secp256k1_fe_t *r, const secp256k1_fe_t *a, const secp256k1_fe_t * SECP256K1_RESTRICT b) {
+static void secp256k1_fe_mul(secp256k1_fe *r, const secp256k1_fe *a, const secp256k1_fe * SECP256K1_RESTRICT b) {
 #ifdef VERIFY
     VERIFY_CHECK(a->magnitude <= 8);
     VERIFY_CHECK(b->magnitude <= 8);
@@ -1055,7 +1055,7 @@ static void secp256k1_fe_mul(secp256k1_fe_t *r, const secp256k1_fe_t *a, const s
 #endif
 }
 
-static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
+static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a) {
 #ifdef VERIFY
     VERIFY_CHECK(a->magnitude <= 8);
     secp256k1_fe_verify(a);
@@ -1068,7 +1068,7 @@ static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #endif
 }
 
-static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag) {
+static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_fe *a, int flag) {
     uint32_t mask0, mask1;
     mask0 = flag + ~((uint32_t)0);
     mask1 = ~mask0;
@@ -1090,7 +1090,7 @@ static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k
 #endif
 }
 
-static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag) {
+static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage *r, const secp256k1_fe_storage *a, int flag) {
     uint32_t mask0, mask1;
     mask0 = flag + ~((uint32_t)0);
     mask1 = ~mask0;
@@ -1104,7 +1104,7 @@ static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r
     r->n[7] = (r->n[7] & mask0) | (a->n[7] & mask1);
 }
 
-static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_fe_t *a) {
+static void secp256k1_fe_to_storage(secp256k1_fe_storage *r, const secp256k1_fe *a) {
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
 #endif
@@ -1118,7 +1118,7 @@ static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_f
     r->n[7] = a->n[8] >> 16 | a->n[9] << 10;
 }
 
-static SECP256K1_INLINE void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_storage_t *a) {
+static SECP256K1_INLINE void secp256k1_fe_from_storage(secp256k1_fe *r, const secp256k1_fe_storage *a) {
     r->n[0] = a->n[0] & 0x3FFFFFFUL;
     r->n[1] = a->n[0] >> 26 | ((a->n[1] << 6) & 0x3FFFFFFUL);
     r->n[2] = a->n[1] >> 20 | ((a->n[2] << 12) & 0x3FFFFFFUL);

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -16,7 +16,7 @@ typedef struct {
     int magnitude;
     int normalized;
 #endif
-} secp256k1_fe_t;
+} secp256k1_fe;
 
 /* Unpacks a constant into a overlapping multi-limbed FE element. */
 #define SECP256K1_FE_CONST_INNER(d7, d6, d5, d4, d3, d2, d1, d0) { \
@@ -35,7 +35,7 @@ typedef struct {
 
 typedef struct {
     uint64_t n[4];
-} secp256k1_fe_storage_t;
+} secp256k1_fe_storage;
 
 #define SECP256K1_FE_STORAGE_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{ \
     (d0) | ((uint64_t)(d1)) << 32, \

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -31,7 +31,7 @@
  */
 
 #ifdef VERIFY
-static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
+static void secp256k1_fe_verify(const secp256k1_fe *a) {
     const uint64_t *d = a->n;
     int m = a->normalized ? 1 : 2 * a->magnitude, r = 1;
    /* secp256k1 'p' value defined in "Standards for Efficient Cryptography" (SEC2) 2.7.1. */
@@ -51,12 +51,12 @@ static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
     VERIFY_CHECK(r == 1);
 }
 #else
-static void secp256k1_fe_verify(const secp256k1_fe_t *a) {
+static void secp256k1_fe_verify(const secp256k1_fe *a) {
     (void)a;
 }
 #endif
 
-static void secp256k1_fe_normalize(secp256k1_fe_t *r) {
+static void secp256k1_fe_normalize(secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 
     /* Reduce t4 at the start so there will be at most a single carry from the first pass */
@@ -99,7 +99,7 @@ static void secp256k1_fe_normalize(secp256k1_fe_t *r) {
 #endif
 }
 
-static void secp256k1_fe_normalize_weak(secp256k1_fe_t *r) {
+static void secp256k1_fe_normalize_weak(secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 
     /* Reduce t4 at the start so there will be at most a single carry from the first pass */
@@ -123,7 +123,7 @@ static void secp256k1_fe_normalize_weak(secp256k1_fe_t *r) {
 #endif
 }
 
-static void secp256k1_fe_normalize_var(secp256k1_fe_t *r) {
+static void secp256k1_fe_normalize_var(secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 
     /* Reduce t4 at the start so there will be at most a single carry from the first pass */
@@ -167,7 +167,7 @@ static void secp256k1_fe_normalize_var(secp256k1_fe_t *r) {
 #endif
 }
 
-static int secp256k1_fe_normalizes_to_zero(secp256k1_fe_t *r) {
+static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 
     /* z0 tracks a possible raw value of 0, z1 tracks a possible raw value of P */
@@ -190,7 +190,7 @@ static int secp256k1_fe_normalizes_to_zero(secp256k1_fe_t *r) {
     return (z0 == 0) | (z1 == 0xFFFFFFFFFFFFFULL);
 }
 
-static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe_t *r) {
+static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r) {
     uint64_t t0, t1, t2, t3, t4;
     uint64_t z0, z1;
     uint64_t x;
@@ -231,7 +231,7 @@ static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe_t *r) {
     return (z0 == 0) | (z1 == 0xFFFFFFFFFFFFFULL);
 }
 
-SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe_t *r, int a) {
+SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe *r, int a) {
     r->n[0] = a;
     r->n[1] = r->n[2] = r->n[3] = r->n[4] = 0;
 #ifdef VERIFY
@@ -241,7 +241,7 @@ SECP256K1_INLINE static void secp256k1_fe_set_int(secp256k1_fe_t *r, int a) {
 #endif
 }
 
-SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe_t *a) {
+SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe *a) {
     const uint64_t *t = a->n;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
@@ -250,7 +250,7 @@ SECP256K1_INLINE static int secp256k1_fe_is_zero(const secp256k1_fe_t *a) {
     return (t[0] | t[1] | t[2] | t[3] | t[4]) == 0;
 }
 
-SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe_t *a) {
+SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe *a) {
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
     secp256k1_fe_verify(a);
@@ -258,7 +258,7 @@ SECP256K1_INLINE static int secp256k1_fe_is_odd(const secp256k1_fe_t *a) {
     return a->n[0] & 1;
 }
 
-SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe_t *a) {
+SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe *a) {
     int i;
 #ifdef VERIFY
     a->magnitude = 0;
@@ -269,7 +269,7 @@ SECP256K1_INLINE static void secp256k1_fe_clear(secp256k1_fe_t *a) {
     }
 }
 
-static int secp256k1_fe_cmp_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b) {
+static int secp256k1_fe_cmp_var(const secp256k1_fe *a, const secp256k1_fe *b) {
     int i;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
@@ -288,7 +288,7 @@ static int secp256k1_fe_cmp_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b
     return 0;
 }
 
-static int secp256k1_fe_set_b32(secp256k1_fe_t *r, const unsigned char *a) {
+static int secp256k1_fe_set_b32(secp256k1_fe *r, const unsigned char *a) {
     int i;
     r->n[0] = r->n[1] = r->n[2] = r->n[3] = r->n[4] = 0;
     for (i=0; i<32; i++) {
@@ -311,7 +311,7 @@ static int secp256k1_fe_set_b32(secp256k1_fe_t *r, const unsigned char *a) {
 }
 
 /** Convert a field element to a 32-byte big endian value. Requires the input to be normalized */
-static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe_t *a) {
+static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe *a) {
     int i;
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
@@ -329,7 +329,7 @@ static void secp256k1_fe_get_b32(unsigned char *r, const secp256k1_fe_t *a) {
     }
 }
 
-SECP256K1_INLINE static void secp256k1_fe_negate(secp256k1_fe_t *r, const secp256k1_fe_t *a, int m) {
+SECP256K1_INLINE static void secp256k1_fe_negate(secp256k1_fe *r, const secp256k1_fe *a, int m) {
 #ifdef VERIFY
     VERIFY_CHECK(a->magnitude <= m);
     secp256k1_fe_verify(a);
@@ -346,7 +346,7 @@ SECP256K1_INLINE static void secp256k1_fe_negate(secp256k1_fe_t *r, const secp25
 #endif
 }
 
-SECP256K1_INLINE static void secp256k1_fe_mul_int(secp256k1_fe_t *r, int a) {
+SECP256K1_INLINE static void secp256k1_fe_mul_int(secp256k1_fe *r, int a) {
     r->n[0] *= a;
     r->n[1] *= a;
     r->n[2] *= a;
@@ -359,7 +359,7 @@ SECP256K1_INLINE static void secp256k1_fe_mul_int(secp256k1_fe_t *r, int a) {
 #endif
 }
 
-SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
+SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe *r, const secp256k1_fe *a) {
 #ifdef VERIFY
     secp256k1_fe_verify(a);
 #endif
@@ -375,7 +375,7 @@ SECP256K1_INLINE static void secp256k1_fe_add(secp256k1_fe_t *r, const secp256k1
 #endif
 }
 
-static void secp256k1_fe_mul(secp256k1_fe_t *r, const secp256k1_fe_t *a, const secp256k1_fe_t * SECP256K1_RESTRICT b) {
+static void secp256k1_fe_mul(secp256k1_fe *r, const secp256k1_fe *a, const secp256k1_fe * SECP256K1_RESTRICT b) {
 #ifdef VERIFY
     VERIFY_CHECK(a->magnitude <= 8);
     VERIFY_CHECK(b->magnitude <= 8);
@@ -391,7 +391,7 @@ static void secp256k1_fe_mul(secp256k1_fe_t *r, const secp256k1_fe_t *a, const s
 #endif
 }
 
-static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
+static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a) {
 #ifdef VERIFY
     VERIFY_CHECK(a->magnitude <= 8);
     secp256k1_fe_verify(a);
@@ -404,7 +404,7 @@ static void secp256k1_fe_sqr(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #endif
 }
 
-static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k1_fe_t *a, int flag) {
+static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe *r, const secp256k1_fe *a, int flag) {
     uint64_t mask0, mask1;
     mask0 = flag + ~((uint64_t)0);
     mask1 = ~mask0;
@@ -421,7 +421,7 @@ static SECP256K1_INLINE void secp256k1_fe_cmov(secp256k1_fe_t *r, const secp256k
 #endif
 }
 
-static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r, const secp256k1_fe_storage_t *a, int flag) {
+static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage *r, const secp256k1_fe_storage *a, int flag) {
     uint64_t mask0, mask1;
     mask0 = flag + ~((uint64_t)0);
     mask1 = ~mask0;
@@ -431,7 +431,7 @@ static SECP256K1_INLINE void secp256k1_fe_storage_cmov(secp256k1_fe_storage_t *r
     r->n[3] = (r->n[3] & mask0) | (a->n[3] & mask1);
 }
 
-static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_fe_t *a) {
+static void secp256k1_fe_to_storage(secp256k1_fe_storage *r, const secp256k1_fe *a) {
 #ifdef VERIFY
     VERIFY_CHECK(a->normalized);
 #endif
@@ -441,7 +441,7 @@ static void secp256k1_fe_to_storage(secp256k1_fe_storage_t *r, const secp256k1_f
     r->n[3] = a->n[3] >> 36 | a->n[4] << 16;
 }
 
-static SECP256K1_INLINE void secp256k1_fe_from_storage(secp256k1_fe_t *r, const secp256k1_fe_storage_t *a) {
+static SECP256K1_INLINE void secp256k1_fe_from_storage(secp256k1_fe *r, const secp256k1_fe_storage *a) {
     r->n[0] = a->n[0] & 0xFFFFFFFFFFFFFULL;
     r->n[1] = a->n[0] >> 52 | ((a->n[1] << 12) & 0xFFFFFFFFFFFFFULL);
     r->n[2] = a->n[1] >> 40 | ((a->n[2] << 24) & 0xFFFFFFFFFFFFFULL);

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -21,15 +21,15 @@
 #error "Please select field implementation"
 #endif
 
-SECP256K1_INLINE static int secp256k1_fe_equal_var(const secp256k1_fe_t *a, const secp256k1_fe_t *b) {
-    secp256k1_fe_t na;
+SECP256K1_INLINE static int secp256k1_fe_equal_var(const secp256k1_fe *a, const secp256k1_fe *b) {
+    secp256k1_fe na;
     secp256k1_fe_negate(&na, a, 1);
     secp256k1_fe_add(&na, b);
     return secp256k1_fe_normalizes_to_zero_var(&na);
 }
 
-static int secp256k1_fe_sqrt_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
-    secp256k1_fe_t x2, x3, x6, x9, x11, x22, x44, x88, x176, x220, x223, t1;
+static int secp256k1_fe_sqrt_var(secp256k1_fe *r, const secp256k1_fe *a) {
+    secp256k1_fe x2, x3, x6, x9, x11, x22, x44, x88, x176, x220, x223, t1;
     int j;
 
     /** The binary representation of (p + 1)/4 has 3 blocks of 1s, with lengths in
@@ -117,8 +117,8 @@ static int secp256k1_fe_sqrt_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     return secp256k1_fe_equal_var(&t1, a);
 }
 
-static void secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
-    secp256k1_fe_t x2, x3, x6, x9, x11, x22, x44, x88, x176, x220, x223, t1;
+static void secp256k1_fe_inv(secp256k1_fe *r, const secp256k1_fe *a) {
+    secp256k1_fe x2, x3, x6, x9, x11, x22, x44, x88, x176, x220, x223, t1;
     int j;
 
     /** The binary representation of (p - 2) has 5 blocks of 1s, with lengths in
@@ -207,12 +207,12 @@ static void secp256k1_fe_inv(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
     secp256k1_fe_mul(r, a, &t1);
 }
 
-static void secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
+static void secp256k1_fe_inv_var(secp256k1_fe *r, const secp256k1_fe *a) {
 #if defined(USE_FIELD_INV_BUILTIN)
     secp256k1_fe_inv(r, a);
 #elif defined(USE_FIELD_INV_NUM)
-    secp256k1_num_t n, m;
-    static const secp256k1_fe_t negone = SECP256K1_FE_CONST(
+    secp256k1_num n, m;
+    static const secp256k1_fe negone = SECP256K1_FE_CONST(
         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF,
         0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFE, 0xFFFFFC2E
     );
@@ -224,7 +224,7 @@ static void secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
         0xFF,0xFF,0xFF,0xFE,0xFF,0xFF,0xFC,0x2F
     };
     unsigned char b[32];
-    secp256k1_fe_t c = *a;
+    secp256k1_fe c = *a;
     secp256k1_fe_normalize_var(&c);
     secp256k1_fe_get_b32(b, &c);
     secp256k1_num_set_bin(&n, b, 32);
@@ -241,8 +241,8 @@ static void secp256k1_fe_inv_var(secp256k1_fe_t *r, const secp256k1_fe_t *a) {
 #endif
 }
 
-static void secp256k1_fe_inv_all_var(size_t len, secp256k1_fe_t *r, const secp256k1_fe_t *a) {
-    secp256k1_fe_t u;
+static void secp256k1_fe_inv_all_var(size_t len, secp256k1_fe *r, const secp256k1_fe *a) {
+    secp256k1_fe u;
     size_t i;
     if (len < 1) {
         return;

--- a/src/gen_context.c
+++ b/src/gen_context.c
@@ -19,13 +19,13 @@ static void default_error_callback_fn(const char* str, void* data) {
     abort();
 }
 
-static const callback_t default_error_callback = {
+static const secp256k1_callback default_error_callback = {
     default_error_callback_fn,
     NULL
 };
 
 int main(int argc, char **argv) {
-    secp256k1_ecmult_gen_context_t ctx;
+    secp256k1_ecmult_gen_context ctx;
     int inner;
     int outer;
     FILE* fp;
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
     fprintf(fp, "#define _SECP256K1_ECMULT_STATIC_CONTEXT_\n");
     fprintf(fp, "#include \"group.h\"\n");
     fprintf(fp, "#define SC SECP256K1_GE_STORAGE_CONST\n");
-    fprintf(fp, "static const secp256k1_ge_storage_t secp256k1_ecmult_static_context[64][16] = {\n");
+    fprintf(fp, "static const secp256k1_ge_storage secp256k1_ecmult_static_context[64][16] = {\n");
 
     secp256k1_ecmult_gen_context_init(&ctx);
     secp256k1_ecmult_gen_context_build(&ctx, &default_error_callback);

--- a/src/group.h
+++ b/src/group.h
@@ -12,130 +12,130 @@
 
 /** A group element of the secp256k1 curve, in affine coordinates. */
 typedef struct {
-    secp256k1_fe_t x;
-    secp256k1_fe_t y;
+    secp256k1_fe x;
+    secp256k1_fe y;
     int infinity; /* whether this represents the point at infinity */
-} secp256k1_ge_t;
+} secp256k1_ge;
 
 #define SECP256K1_GE_CONST(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {SECP256K1_FE_CONST((a),(b),(c),(d),(e),(f),(g),(h)), SECP256K1_FE_CONST((i),(j),(k),(l),(m),(n),(o),(p)), 0}
 #define SECP256K1_GE_CONST_INFINITY {SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), 1}
 
 /** A group element of the secp256k1 curve, in jacobian coordinates. */
 typedef struct {
-    secp256k1_fe_t x; /* actual X: x/z^2 */
-    secp256k1_fe_t y; /* actual Y: y/z^3 */
-    secp256k1_fe_t z;
+    secp256k1_fe x; /* actual X: x/z^2 */
+    secp256k1_fe y; /* actual Y: y/z^3 */
+    secp256k1_fe z;
     int infinity; /* whether this represents the point at infinity */
-} secp256k1_gej_t;
+} secp256k1_gej;
 
 #define SECP256K1_GEJ_CONST(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {SECP256K1_FE_CONST((a),(b),(c),(d),(e),(f),(g),(h)), SECP256K1_FE_CONST((i),(j),(k),(l),(m),(n),(o),(p)), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 1), 0}
 #define SECP256K1_GEJ_CONST_INFINITY {SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 0), 1}
 
 typedef struct {
-    secp256k1_fe_storage_t x;
-    secp256k1_fe_storage_t y;
-} secp256k1_ge_storage_t;
+    secp256k1_fe_storage x;
+    secp256k1_fe_storage y;
+} secp256k1_ge_storage;
 
 #define SECP256K1_GE_STORAGE_CONST(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {SECP256K1_FE_STORAGE_CONST((a),(b),(c),(d),(e),(f),(g),(h)), SECP256K1_FE_STORAGE_CONST((i),(j),(k),(l),(m),(n),(o),(p))}
 
 #define SECP256K1_GE_STORAGE_CONST_GET(t) SECP256K1_FE_STORAGE_CONST_GET(t.x), SECP256K1_FE_STORAGE_CONST_GET(t.y)
 
 /** Set a group element equal to the point at infinity */
-static void secp256k1_ge_set_infinity(secp256k1_ge_t *r);
+static void secp256k1_ge_set_infinity(secp256k1_ge *r);
 
 /** Set a group element equal to the point with given X and Y coordinates */
-static void secp256k1_ge_set_xy(secp256k1_ge_t *r, const secp256k1_fe_t *x, const secp256k1_fe_t *y);
+static void secp256k1_ge_set_xy(secp256k1_ge *r, const secp256k1_fe *x, const secp256k1_fe *y);
 
 /** Set a group element (affine) equal to the point with the given X coordinate, and given oddness
  *  for Y. Return value indicates whether the result is valid. */
-static int secp256k1_ge_set_xo_var(secp256k1_ge_t *r, const secp256k1_fe_t *x, int odd);
+static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd);
 
 /** Check whether a group element is the point at infinity. */
-static int secp256k1_ge_is_infinity(const secp256k1_ge_t *a);
+static int secp256k1_ge_is_infinity(const secp256k1_ge *a);
 
 /** Check whether a group element is valid (i.e., on the curve). */
-static int secp256k1_ge_is_valid_var(const secp256k1_ge_t *a);
+static int secp256k1_ge_is_valid_var(const secp256k1_ge *a);
 
-static void secp256k1_ge_neg(secp256k1_ge_t *r, const secp256k1_ge_t *a);
+static void secp256k1_ge_neg(secp256k1_ge *r, const secp256k1_ge *a);
 
 /** Set a group element equal to another which is given in jacobian coordinates */
-static void secp256k1_ge_set_gej(secp256k1_ge_t *r, secp256k1_gej_t *a);
+static void secp256k1_ge_set_gej(secp256k1_ge *r, secp256k1_gej *a);
 
 /** Set a batch of group elements equal to the inputs given in jacobian coordinates */
-static void secp256k1_ge_set_all_gej_var(size_t len, secp256k1_ge_t *r, const secp256k1_gej_t *a, const callback_t *cb);
+static void secp256k1_ge_set_all_gej_var(size_t len, secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_callback *cb);
 
 /** Set a batch of group elements equal to the inputs given in jacobian
  *  coordinates (with known z-ratios). zr must contain the known z-ratios such
  *  that mul(a[i].z, zr[i+1]) == a[i+1].z. zr[0] is ignored. */
-static void secp256k1_ge_set_table_gej_var(size_t len, secp256k1_ge_t *r, const secp256k1_gej_t *a, const secp256k1_fe_t *zr);
+static void secp256k1_ge_set_table_gej_var(size_t len, secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zr);
 
 /** Bring a batch inputs given in jacobian coordinates (with known z-ratios) to
  *  the same global z "denominator". zr must contain the known z-ratios such
  *  that mul(a[i].z, zr[i+1]) == a[i+1].z. zr[0] is ignored. The x and y
  *  coordinates of the result are stored in r, the common z coordinate is
  *  stored in globalz. */
-static void secp256k1_ge_globalz_set_table_gej(size_t len, secp256k1_ge_t *r, secp256k1_fe_t *globalz, const secp256k1_gej_t *a, const secp256k1_fe_t *zr);
+static void secp256k1_ge_globalz_set_table_gej(size_t len, secp256k1_ge *r, secp256k1_fe *globalz, const secp256k1_gej *a, const secp256k1_fe *zr);
 
 /** Set a group element (jacobian) equal to the point at infinity. */
-static void secp256k1_gej_set_infinity(secp256k1_gej_t *r);
+static void secp256k1_gej_set_infinity(secp256k1_gej *r);
 
 /** Set a group element (jacobian) equal to the point with given X and Y coordinates. */
-static void secp256k1_gej_set_xy(secp256k1_gej_t *r, const secp256k1_fe_t *x, const secp256k1_fe_t *y);
+static void secp256k1_gej_set_xy(secp256k1_gej *r, const secp256k1_fe *x, const secp256k1_fe *y);
 
 /** Set a group element (jacobian) equal to another which is given in affine coordinates. */
-static void secp256k1_gej_set_ge(secp256k1_gej_t *r, const secp256k1_ge_t *a);
+static void secp256k1_gej_set_ge(secp256k1_gej *r, const secp256k1_ge *a);
 
 /** Compare the X coordinate of a group element (jacobian). */
-static int secp256k1_gej_eq_x_var(const secp256k1_fe_t *x, const secp256k1_gej_t *a);
+static int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a);
 
 /** Set r equal to the inverse of a (i.e., mirrored around the X axis) */
-static void secp256k1_gej_neg(secp256k1_gej_t *r, const secp256k1_gej_t *a);
+static void secp256k1_gej_neg(secp256k1_gej *r, const secp256k1_gej *a);
 
 /** Check whether a group element is the point at infinity. */
-static int secp256k1_gej_is_infinity(const secp256k1_gej_t *a);
+static int secp256k1_gej_is_infinity(const secp256k1_gej *a);
 
 /** Set r equal to the double of a. If rzr is not-NULL, r->z = a->z * *rzr (where infinity means an implicit z = 0).
  * a may not be zero. Constant time. */
-static void secp256k1_gej_double_nonzero(secp256k1_gej_t *r, const secp256k1_gej_t *a, secp256k1_fe_t *rzr);
+static void secp256k1_gej_double_nonzero(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr);
 
 /** Set r equal to the double of a. If rzr is not-NULL, r->z = a->z * *rzr (where infinity means an implicit z = 0). */
-static void secp256k1_gej_double_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, secp256k1_fe_t *rzr);
+static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr);
 
 /** Set r equal to the sum of a and b. If rzr is non-NULL, r->z = a->z * *rzr (a cannot be infinity in that case). */
-static void secp256k1_gej_add_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_gej_t *b, secp256k1_fe_t *rzr);
+static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr);
 
 /** Set r equal to the sum of a and b (with b given in affine coordinates, and not infinity). */
-static void secp256k1_gej_add_ge(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b);
+static void secp256k1_gej_add_ge(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b);
 
 /** Set r equal to the sum of a and b (with b given in affine coordinates). This is more efficient
     than secp256k1_gej_add_var. It is identical to secp256k1_gej_add_ge but without constant-time
     guarantee, and b is allowed to be infinity. If rzr is non-NULL, r->z = a->z * *rzr (a cannot be infinity in that case). */
-static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b, secp256k1_fe_t *rzr);
+static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, secp256k1_fe *rzr);
 
 /** Set r equal to the sum of a and b (with the inverse of b's Z coordinate passed as bzinv). */
-static void secp256k1_gej_add_zinv_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b, const secp256k1_fe_t *bzinv);
+static void secp256k1_gej_add_zinv_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, const secp256k1_fe *bzinv);
 
 #ifdef USE_ENDOMORPHISM
 /** Set r to be equal to lambda times a, where lambda is chosen in a way such that this is very fast. */
-static void secp256k1_ge_mul_lambda(secp256k1_ge_t *r, const secp256k1_ge_t *a);
+static void secp256k1_ge_mul_lambda(secp256k1_ge *r, const secp256k1_ge *a);
 #endif
 
-/** Clear a secp256k1_gej_t to prevent leaking sensitive information. */
-static void secp256k1_gej_clear(secp256k1_gej_t *r);
+/** Clear a secp256k1_gej to prevent leaking sensitive information. */
+static void secp256k1_gej_clear(secp256k1_gej *r);
 
-/** Clear a secp256k1_ge_t to prevent leaking sensitive information. */
-static void secp256k1_ge_clear(secp256k1_ge_t *r);
+/** Clear a secp256k1_ge to prevent leaking sensitive information. */
+static void secp256k1_ge_clear(secp256k1_ge *r);
 
 /** Convert a group element to the storage type. */
-static void secp256k1_ge_to_storage(secp256k1_ge_storage_t *r, const secp256k1_ge_t*);
+static void secp256k1_ge_to_storage(secp256k1_ge_storage *r, const secp256k1_ge*);
 
 /** Convert a group element back from the storage type. */
-static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_storage_t*);
+static void secp256k1_ge_from_storage(secp256k1_ge *r, const secp256k1_ge_storage*);
 
 /** If flag is true, set *r equal to *a; otherwise leave it. Constant-time. */
-static void secp256k1_ge_storage_cmov(secp256k1_ge_storage_t *r, const secp256k1_ge_storage_t *a, int flag);
+static void secp256k1_ge_storage_cmov(secp256k1_ge_storage *r, const secp256k1_ge_storage *a, int flag);
 
 /** Rescale a jacobian point by b which must be non-zero. Constant-time. */
-static void secp256k1_gej_rescale(secp256k1_gej_t *r, const secp256k1_fe_t *b);
+static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *b);
 
 #endif

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -16,16 +16,16 @@
 /** Generator for secp256k1, value 'g' defined in
  *  "Standards for Efficient Cryptography" (SEC2) 2.7.1.
  */
-static const secp256k1_ge_t secp256k1_ge_const_g = SECP256K1_GE_CONST(
+static const secp256k1_ge secp256k1_ge_const_g = SECP256K1_GE_CONST(
     0x79BE667EUL, 0xF9DCBBACUL, 0x55A06295UL, 0xCE870B07UL,
     0x029BFCDBUL, 0x2DCE28D9UL, 0x59F2815BUL, 0x16F81798UL,
     0x483ADA77UL, 0x26A3C465UL, 0x5DA4FBFCUL, 0x0E1108A8UL,
     0xFD17B448UL, 0xA6855419UL, 0x9C47D08FUL, 0xFB10D4B8UL
 );
 
-static void secp256k1_ge_set_gej_zinv(secp256k1_ge_t *r, const secp256k1_gej_t *a, const secp256k1_fe_t *zi) {
-    secp256k1_fe_t zi2; 
-    secp256k1_fe_t zi3;
+static void secp256k1_ge_set_gej_zinv(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zi) {
+    secp256k1_fe zi2; 
+    secp256k1_fe zi3;
     secp256k1_fe_sqr(&zi2, zi);
     secp256k1_fe_mul(&zi3, &zi2, zi);
     secp256k1_fe_mul(&r->x, &a->x, &zi2);
@@ -33,28 +33,28 @@ static void secp256k1_ge_set_gej_zinv(secp256k1_ge_t *r, const secp256k1_gej_t *
     r->infinity = a->infinity;
 }
 
-static void secp256k1_ge_set_infinity(secp256k1_ge_t *r) {
+static void secp256k1_ge_set_infinity(secp256k1_ge *r) {
     r->infinity = 1;
 }
 
-static void secp256k1_ge_set_xy(secp256k1_ge_t *r, const secp256k1_fe_t *x, const secp256k1_fe_t *y) {
+static void secp256k1_ge_set_xy(secp256k1_ge *r, const secp256k1_fe *x, const secp256k1_fe *y) {
     r->infinity = 0;
     r->x = *x;
     r->y = *y;
 }
 
-static int secp256k1_ge_is_infinity(const secp256k1_ge_t *a) {
+static int secp256k1_ge_is_infinity(const secp256k1_ge *a) {
     return a->infinity;
 }
 
-static void secp256k1_ge_neg(secp256k1_ge_t *r, const secp256k1_ge_t *a) {
+static void secp256k1_ge_neg(secp256k1_ge *r, const secp256k1_ge *a) {
     *r = *a;
     secp256k1_fe_normalize_weak(&r->y);
     secp256k1_fe_negate(&r->y, &r->y, 1);
 }
 
-static void secp256k1_ge_set_gej(secp256k1_ge_t *r, secp256k1_gej_t *a) {
-    secp256k1_fe_t z2, z3;
+static void secp256k1_ge_set_gej(secp256k1_ge *r, secp256k1_gej *a) {
+    secp256k1_fe z2, z3;
     r->infinity = a->infinity;
     secp256k1_fe_inv(&a->z, &a->z);
     secp256k1_fe_sqr(&z2, &a->z);
@@ -66,8 +66,8 @@ static void secp256k1_ge_set_gej(secp256k1_ge_t *r, secp256k1_gej_t *a) {
     r->y = a->y;
 }
 
-static void secp256k1_ge_set_gej_var(secp256k1_ge_t *r, secp256k1_gej_t *a) {
-    secp256k1_fe_t z2, z3;
+static void secp256k1_ge_set_gej_var(secp256k1_ge *r, secp256k1_gej *a) {
+    secp256k1_fe z2, z3;
     r->infinity = a->infinity;
     if (a->infinity) {
         return;
@@ -82,19 +82,19 @@ static void secp256k1_ge_set_gej_var(secp256k1_ge_t *r, secp256k1_gej_t *a) {
     r->y = a->y;
 }
 
-static void secp256k1_ge_set_all_gej_var(size_t len, secp256k1_ge_t *r, const secp256k1_gej_t *a, const callback_t *cb) {
-    secp256k1_fe_t *az;
-    secp256k1_fe_t *azi;
+static void secp256k1_ge_set_all_gej_var(size_t len, secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_callback *cb) {
+    secp256k1_fe *az;
+    secp256k1_fe *azi;
     size_t i;
     size_t count = 0;
-    az = (secp256k1_fe_t *)checked_malloc(cb, sizeof(secp256k1_fe_t) * len);
+    az = (secp256k1_fe *)checked_malloc(cb, sizeof(secp256k1_fe) * len);
     for (i = 0; i < len; i++) {
         if (!a[i].infinity) {
             az[count++] = a[i].z;
         }
     }
 
-    azi = (secp256k1_fe_t *)checked_malloc(cb, sizeof(secp256k1_fe_t) * count);
+    azi = (secp256k1_fe *)checked_malloc(cb, sizeof(secp256k1_fe) * count);
     secp256k1_fe_inv_all_var(count, azi, az);
     free(az);
 
@@ -108,9 +108,9 @@ static void secp256k1_ge_set_all_gej_var(size_t len, secp256k1_ge_t *r, const se
     free(azi);
 }
 
-static void secp256k1_ge_set_table_gej_var(size_t len, secp256k1_ge_t *r, const secp256k1_gej_t *a, const secp256k1_fe_t *zr) {
+static void secp256k1_ge_set_table_gej_var(size_t len, secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zr) {
     size_t i = len - 1;
-    secp256k1_fe_t zi;
+    secp256k1_fe zi;
 
     if (len > 0) {
         /* Compute the inverse of the last z coordinate, and use it to compute the last affine output. */
@@ -126,9 +126,9 @@ static void secp256k1_ge_set_table_gej_var(size_t len, secp256k1_ge_t *r, const 
     }
 }
 
-static void secp256k1_ge_globalz_set_table_gej(size_t len, secp256k1_ge_t *r, secp256k1_fe_t *globalz, const secp256k1_gej_t *a, const secp256k1_fe_t *zr) {
+static void secp256k1_ge_globalz_set_table_gej(size_t len, secp256k1_ge *r, secp256k1_fe *globalz, const secp256k1_gej *a, const secp256k1_fe *zr) {
     size_t i = len - 1;
-    secp256k1_fe_t zs;
+    secp256k1_fe zs;
 
     if (len > 0) {
         /* The z of the final point gives us the "global Z" for the table. */
@@ -149,35 +149,35 @@ static void secp256k1_ge_globalz_set_table_gej(size_t len, secp256k1_ge_t *r, se
     }
 }
 
-static void secp256k1_gej_set_infinity(secp256k1_gej_t *r) {
+static void secp256k1_gej_set_infinity(secp256k1_gej *r) {
     r->infinity = 1;
     secp256k1_fe_set_int(&r->x, 0);
     secp256k1_fe_set_int(&r->y, 0);
     secp256k1_fe_set_int(&r->z, 0);
 }
 
-static void secp256k1_gej_set_xy(secp256k1_gej_t *r, const secp256k1_fe_t *x, const secp256k1_fe_t *y) {
+static void secp256k1_gej_set_xy(secp256k1_gej *r, const secp256k1_fe *x, const secp256k1_fe *y) {
     r->infinity = 0;
     r->x = *x;
     r->y = *y;
     secp256k1_fe_set_int(&r->z, 1);
 }
 
-static void secp256k1_gej_clear(secp256k1_gej_t *r) {
+static void secp256k1_gej_clear(secp256k1_gej *r) {
     r->infinity = 0;
     secp256k1_fe_clear(&r->x);
     secp256k1_fe_clear(&r->y);
     secp256k1_fe_clear(&r->z);
 }
 
-static void secp256k1_ge_clear(secp256k1_ge_t *r) {
+static void secp256k1_ge_clear(secp256k1_ge *r) {
     r->infinity = 0;
     secp256k1_fe_clear(&r->x);
     secp256k1_fe_clear(&r->y);
 }
 
-static int secp256k1_ge_set_xo_var(secp256k1_ge_t *r, const secp256k1_fe_t *x, int odd) {
-    secp256k1_fe_t x2, x3, c;
+static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd) {
+    secp256k1_fe x2, x3, c;
     r->x = *x;
     secp256k1_fe_sqr(&x2, x);
     secp256k1_fe_mul(&x3, x, &x2);
@@ -194,22 +194,22 @@ static int secp256k1_ge_set_xo_var(secp256k1_ge_t *r, const secp256k1_fe_t *x, i
     return 1;
 }
 
-static void secp256k1_gej_set_ge(secp256k1_gej_t *r, const secp256k1_ge_t *a) {
+static void secp256k1_gej_set_ge(secp256k1_gej *r, const secp256k1_ge *a) {
    r->infinity = a->infinity;
    r->x = a->x;
    r->y = a->y;
    secp256k1_fe_set_int(&r->z, 1);
 }
 
-static int secp256k1_gej_eq_x_var(const secp256k1_fe_t *x, const secp256k1_gej_t *a) {
-    secp256k1_fe_t r, r2;
+static int secp256k1_gej_eq_x_var(const secp256k1_fe *x, const secp256k1_gej *a) {
+    secp256k1_fe r, r2;
     VERIFY_CHECK(!a->infinity);
     secp256k1_fe_sqr(&r, &a->z); secp256k1_fe_mul(&r, &r, x);
     r2 = a->x; secp256k1_fe_normalize_weak(&r2);
     return secp256k1_fe_equal_var(&r, &r2);
 }
 
-static void secp256k1_gej_neg(secp256k1_gej_t *r, const secp256k1_gej_t *a) {
+static void secp256k1_gej_neg(secp256k1_gej *r, const secp256k1_gej *a) {
     r->infinity = a->infinity;
     r->x = a->x;
     r->y = a->y;
@@ -218,12 +218,12 @@ static void secp256k1_gej_neg(secp256k1_gej_t *r, const secp256k1_gej_t *a) {
     secp256k1_fe_negate(&r->y, &r->y, 1);
 }
 
-static int secp256k1_gej_is_infinity(const secp256k1_gej_t *a) {
+static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
     return a->infinity;
 }
 
-static int secp256k1_gej_is_valid_var(const secp256k1_gej_t *a) {
-    secp256k1_fe_t y2, x3, z2, z6;
+static int secp256k1_gej_is_valid_var(const secp256k1_gej *a) {
+    secp256k1_fe y2, x3, z2, z6;
     if (a->infinity) {
         return 0;
     }
@@ -242,8 +242,8 @@ static int secp256k1_gej_is_valid_var(const secp256k1_gej_t *a) {
     return secp256k1_fe_equal_var(&y2, &x3);
 }
 
-static int secp256k1_ge_is_valid_var(const secp256k1_ge_t *a) {
-    secp256k1_fe_t y2, x3, c;
+static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
+    secp256k1_fe y2, x3, c;
     if (a->infinity) {
         return 0;
     }
@@ -256,9 +256,9 @@ static int secp256k1_ge_is_valid_var(const secp256k1_ge_t *a) {
     return secp256k1_fe_equal_var(&y2, &x3);
 }
 
-static void secp256k1_gej_double_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, secp256k1_fe_t *rzr) {
+static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr) {
     /* Operations: 3 mul, 4 sqr, 0 normalize, 12 mul_int/add/negate */
-    secp256k1_fe_t t1,t2,t3,t4;
+    secp256k1_fe t1,t2,t3,t4;
     /** For secp256k1, 2Q is infinity if and only if Q is infinity. This is because if 2Q = infinity,
      *  Q must equal -Q, or that Q.y == -(Q.y), or Q.y is 0. For a point on y^2 = x^3 + 7 to have
      *  y=0, x^3 must be -7 mod p. However, -7 has no cube root mod p.
@@ -299,14 +299,14 @@ static void secp256k1_gej_double_var(secp256k1_gej_t *r, const secp256k1_gej_t *
     secp256k1_fe_add(&r->y, &t2);         /* Y' = 36*X^3*Y^2 - 27*X^6 - 8*Y^4 (4) */
 }
 
-static SECP256K1_INLINE void secp256k1_gej_double_nonzero(secp256k1_gej_t *r, const secp256k1_gej_t *a, secp256k1_fe_t *rzr) {
+static SECP256K1_INLINE void secp256k1_gej_double_nonzero(secp256k1_gej *r, const secp256k1_gej *a, secp256k1_fe *rzr) {
     VERIFY_CHECK(!secp256k1_gej_is_infinity(a));
     secp256k1_gej_double_var(r, a, rzr);
 }
 
-static void secp256k1_gej_add_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_gej_t *b, secp256k1_fe_t *rzr) {
+static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_gej *b, secp256k1_fe *rzr) {
     /* Operations: 12 mul, 4 sqr, 2 normalize, 12 mul_int/add/negate */
-    secp256k1_fe_t z22, z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;
+    secp256k1_fe z22, z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;
 
     if (a->infinity) {
         VERIFY_CHECK(rzr == NULL);
@@ -357,9 +357,9 @@ static void secp256k1_gej_add_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, 
     secp256k1_fe_add(&r->y, &h3);
 }
 
-static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b, secp256k1_fe_t *rzr) {
+static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, secp256k1_fe *rzr) {
     /* 8 mul, 3 sqr, 4 normalize, 12 mul_int/add/negate */
-    secp256k1_fe_t z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;
+    secp256k1_fe z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;
     if (a->infinity) {
         VERIFY_CHECK(rzr == NULL);
         secp256k1_gej_set_ge(r, b);
@@ -406,16 +406,16 @@ static void secp256k1_gej_add_ge_var(secp256k1_gej_t *r, const secp256k1_gej_t *
     secp256k1_fe_add(&r->y, &h3);
 }
 
-static void secp256k1_gej_add_zinv_var(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b, const secp256k1_fe_t *bzinv) {
+static void secp256k1_gej_add_zinv_var(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b, const secp256k1_fe *bzinv) {
     /* 9 mul, 3 sqr, 4 normalize, 12 mul_int/add/negate */
-    secp256k1_fe_t az, z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;
+    secp256k1_fe az, z12, u1, u2, s1, s2, h, i, i2, h2, h3, t;
 
     if (b->infinity) {
         *r = *a;
         return;
     }
     if (a->infinity) {
-        secp256k1_fe_t bzinv2, bzinv3;
+        secp256k1_fe bzinv2, bzinv3;
         r->infinity = b->infinity;
         secp256k1_fe_sqr(&bzinv2, bzinv);
         secp256k1_fe_mul(&bzinv3, &bzinv2, bzinv);
@@ -463,11 +463,11 @@ static void secp256k1_gej_add_zinv_var(secp256k1_gej_t *r, const secp256k1_gej_t
 }
 
 
-static void secp256k1_gej_add_ge(secp256k1_gej_t *r, const secp256k1_gej_t *a, const secp256k1_ge_t *b) {
+static void secp256k1_gej_add_ge(secp256k1_gej *r, const secp256k1_gej *a, const secp256k1_ge *b) {
     /* Operations: 7 mul, 5 sqr, 4 normalize, 21 mul_int/add/negate/cmov */
-    static const secp256k1_fe_t fe_1 = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 1);
-    secp256k1_fe_t zz, u1, u2, s1, s2, t, tt, m, n, q, rr;
-    secp256k1_fe_t m_alt, rr_alt;
+    static const secp256k1_fe fe_1 = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 1);
+    secp256k1_fe zz, u1, u2, s1, s2, t, tt, m, n, q, rr;
+    secp256k1_fe m_alt, rr_alt;
     int infinity, degenerate;
     VERIFY_CHECK(!b->infinity);
     VERIFY_CHECK(a->infinity == 0 || a->infinity == 1);
@@ -585,9 +585,9 @@ static void secp256k1_gej_add_ge(secp256k1_gej_t *r, const secp256k1_gej_t *a, c
     r->infinity = infinity;
 }
 
-static void secp256k1_gej_rescale(secp256k1_gej_t *r, const secp256k1_fe_t *s) {
+static void secp256k1_gej_rescale(secp256k1_gej *r, const secp256k1_fe *s) {
     /* Operations: 4 mul, 1 sqr */
-    secp256k1_fe_t zz;
+    secp256k1_fe zz;
     VERIFY_CHECK(!secp256k1_fe_is_zero(s));
     secp256k1_fe_sqr(&zz, s);
     secp256k1_fe_mul(&r->x, &r->x, &zz);                /* r->x *= s^2 */
@@ -596,8 +596,8 @@ static void secp256k1_gej_rescale(secp256k1_gej_t *r, const secp256k1_fe_t *s) {
     secp256k1_fe_mul(&r->z, &r->z, s);                  /* r->z *= s   */
 }
 
-static void secp256k1_ge_to_storage(secp256k1_ge_storage_t *r, const secp256k1_ge_t *a) {
-    secp256k1_fe_t x, y;
+static void secp256k1_ge_to_storage(secp256k1_ge_storage *r, const secp256k1_ge *a) {
+    secp256k1_fe x, y;
     VERIFY_CHECK(!a->infinity);
     x = a->x;
     secp256k1_fe_normalize(&x);
@@ -607,20 +607,20 @@ static void secp256k1_ge_to_storage(secp256k1_ge_storage_t *r, const secp256k1_g
     secp256k1_fe_to_storage(&r->y, &y);
 }
 
-static void secp256k1_ge_from_storage(secp256k1_ge_t *r, const secp256k1_ge_storage_t *a) {
+static void secp256k1_ge_from_storage(secp256k1_ge *r, const secp256k1_ge_storage *a) {
     secp256k1_fe_from_storage(&r->x, &a->x);
     secp256k1_fe_from_storage(&r->y, &a->y);
     r->infinity = 0;
 }
 
-static SECP256K1_INLINE void secp256k1_ge_storage_cmov(secp256k1_ge_storage_t *r, const secp256k1_ge_storage_t *a, int flag) {
+static SECP256K1_INLINE void secp256k1_ge_storage_cmov(secp256k1_ge_storage *r, const secp256k1_ge_storage *a, int flag) {
     secp256k1_fe_storage_cmov(&r->x, &a->x, flag);
     secp256k1_fe_storage_cmov(&r->y, &a->y, flag);
 }
 
 #ifdef USE_ENDOMORPHISM
-static void secp256k1_ge_mul_lambda(secp256k1_ge_t *r, const secp256k1_ge_t *a) {
-    static const secp256k1_fe_t beta = SECP256K1_FE_CONST(
+static void secp256k1_ge_mul_lambda(secp256k1_ge *r, const secp256k1_ge *a) {
+    static const secp256k1_fe beta = SECP256K1_FE_CONST(
         0x7ae96a2bul, 0x657c0710ul, 0x6e64479eul, 0xac3434e9ul,
         0x9cf04975ul, 0x12f58995ul, 0xc1396c28ul, 0x719501eeul
     );

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -9,12 +9,12 @@
 
 #include "ecmult_const_impl.h"
 
-int secp256k1_ecdh(const secp256k1_context_t* ctx, unsigned char *result, const secp256k1_pubkey_t *point, const unsigned char *scalar) {
+int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar) {
     int ret = 0;
     int overflow = 0;
-    secp256k1_gej_t res;
-    secp256k1_ge_t pt;
-    secp256k1_scalar_t s;
+    secp256k1_gej res;
+    secp256k1_ge pt;
+    secp256k1_scalar s;
     ARG_CHECK(result != NULL);
     ARG_CHECK(point != NULL);
     ARG_CHECK(scalar != NULL);

--- a/src/modules/ecdh/tests_impl.h
+++ b/src/modules/ecdh/tests_impl.h
@@ -9,7 +9,7 @@
 
 void test_ecdh_generator_basepoint(void) {
     unsigned char s_one[32] = { 0 };
-    secp256k1_pubkey_t point[2];
+    secp256k1_pubkey point[2];
     int i;
 
     s_one[31] = 1;
@@ -21,7 +21,7 @@ void test_ecdh_generator_basepoint(void) {
         unsigned char output_ser[32];
         unsigned char point_ser[33];
         size_t point_ser_len = sizeof(point_ser);
-        secp256k1_scalar_t s;
+        secp256k1_scalar s;
 
         random_scalar_order(&s);
         secp256k1_scalar_get_b32(s_b32, &s);
@@ -51,8 +51,8 @@ void test_bad_scalar(void) {
     };
     unsigned char s_rand[32] = { 0 };
     unsigned char output[32];
-    secp256k1_scalar_t rand;
-    secp256k1_pubkey_t point;
+    secp256k1_scalar rand;
+    secp256k1_pubkey point;
 
     /* Create random point */
     random_scalar_order(&rand);

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -9,11 +9,11 @@
 
 #include "include/secp256k1_recovery.h"
 
-static void secp256k1_ecdsa_recoverable_signature_load(const secp256k1_context_t* ctx, secp256k1_scalar_t* r, secp256k1_scalar_t* s, int* recid, const secp256k1_ecdsa_recoverable_signature_t* sig) {
+static void secp256k1_ecdsa_recoverable_signature_load(const secp256k1_context* ctx, secp256k1_scalar* r, secp256k1_scalar* s, int* recid, const secp256k1_ecdsa_recoverable_signature* sig) {
     (void)ctx;
-    if (sizeof(secp256k1_scalar_t) == 32) {
-        /* When the secp256k1_scalar_t type is exactly 32 byte, use its
-         * representation inside secp256k1_ecdsa_signature_t, as conversion is very fast.
+    if (sizeof(secp256k1_scalar) == 32) {
+        /* When the secp256k1_scalar type is exactly 32 byte, use its
+         * representation inside secp256k1_ecdsa_signature, as conversion is very fast.
          * Note that secp256k1_ecdsa_signature_save must use the same representation. */
         memcpy(r, &sig->data[0], 32);
         memcpy(s, &sig->data[32], 32);
@@ -24,8 +24,8 @@ static void secp256k1_ecdsa_recoverable_signature_load(const secp256k1_context_t
     *recid = sig->data[64];
 }
 
-static void secp256k1_ecdsa_recoverable_signature_save(secp256k1_ecdsa_recoverable_signature_t* sig, const secp256k1_scalar_t* r, const secp256k1_scalar_t* s, int recid) {
-    if (sizeof(secp256k1_scalar_t) == 32) {
+static void secp256k1_ecdsa_recoverable_signature_save(secp256k1_ecdsa_recoverable_signature* sig, const secp256k1_scalar* r, const secp256k1_scalar* s, int recid) {
+    if (sizeof(secp256k1_scalar) == 32) {
         memcpy(&sig->data[0], r, 32);
         memcpy(&sig->data[32], s, 32);
     } else {
@@ -35,8 +35,8 @@ static void secp256k1_ecdsa_recoverable_signature_save(secp256k1_ecdsa_recoverab
     sig->data[64] = recid;
 }
 
-int secp256k1_ecdsa_recoverable_signature_parse_compact(const secp256k1_context_t* ctx, secp256k1_ecdsa_recoverable_signature_t* sig, const unsigned char *input64, int recid) {
-    secp256k1_scalar_t r, s;
+int secp256k1_ecdsa_recoverable_signature_parse_compact(const secp256k1_context* ctx, secp256k1_ecdsa_recoverable_signature* sig, const unsigned char *input64, int recid) {
+    secp256k1_scalar r, s;
     int ret = 1;
     int overflow = 0;
 
@@ -57,8 +57,8 @@ int secp256k1_ecdsa_recoverable_signature_parse_compact(const secp256k1_context_
     return ret;
 }
 
-int secp256k1_ecdsa_recoverable_signature_serialize_compact(const secp256k1_context_t* ctx, unsigned char *output64, int *recid, const secp256k1_ecdsa_recoverable_signature_t* sig) {
-    secp256k1_scalar_t r, s;
+int secp256k1_ecdsa_recoverable_signature_serialize_compact(const secp256k1_context* ctx, unsigned char *output64, int *recid, const secp256k1_ecdsa_recoverable_signature* sig) {
+    secp256k1_scalar r, s;
 
     (void)ctx;
     ARG_CHECK(output64 != NULL);
@@ -70,8 +70,8 @@ int secp256k1_ecdsa_recoverable_signature_serialize_compact(const secp256k1_cont
     return 1;
 }
 
-int secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context_t* ctx, secp256k1_ecdsa_signature_t* sig, const secp256k1_ecdsa_recoverable_signature_t* sigin) {
-    secp256k1_scalar_t r, s;
+int secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const secp256k1_ecdsa_recoverable_signature* sigin) {
+    secp256k1_scalar r, s;
     int recid;
 
     (void)ctx;
@@ -83,9 +83,9 @@ int secp256k1_ecdsa_recoverable_signature_convert(const secp256k1_context_t* ctx
     return 1;
 }
 
-int secp256k1_ecdsa_sign_recoverable(const secp256k1_context_t* ctx, secp256k1_ecdsa_recoverable_signature_t *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function_t noncefp, const void* noncedata) {
-    secp256k1_scalar_t r, s;
-    secp256k1_scalar_t sec, non, msg;
+int secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
+    secp256k1_scalar r, s;
+    secp256k1_scalar sec, non, msg;
     int recid;
     int ret = 0;
     int overflow = 0;
@@ -130,10 +130,10 @@ int secp256k1_ecdsa_sign_recoverable(const secp256k1_context_t* ctx, secp256k1_e
     return ret;
 }
 
-int secp256k1_ecdsa_recover(const secp256k1_context_t* ctx, secp256k1_pubkey_t *pubkey, const secp256k1_ecdsa_recoverable_signature_t *signature, const unsigned char *msg32) {
-    secp256k1_ge_t q;
-    secp256k1_scalar_t r, s;
-    secp256k1_scalar_t m;
+int secp256k1_ecdsa_recover(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32) {
+    secp256k1_ge q;
+    secp256k1_scalar r, s;
+    secp256k1_scalar m;
     int recid;
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));

--- a/src/modules/recovery/tests_impl.h
+++ b/src/modules/recovery/tests_impl.h
@@ -11,16 +11,16 @@ void test_ecdsa_recovery_end_to_end(void) {
     unsigned char extra[32] = {0x00};
     unsigned char privkey[32];
     unsigned char message[32];
-    secp256k1_ecdsa_signature_t signature[5];
-    secp256k1_ecdsa_recoverable_signature_t rsignature[5];
+    secp256k1_ecdsa_signature signature[5];
+    secp256k1_ecdsa_recoverable_signature rsignature[5];
     unsigned char sig[74];
-    secp256k1_pubkey_t pubkey;
-    secp256k1_pubkey_t recpubkey;
+    secp256k1_pubkey pubkey;
+    secp256k1_pubkey recpubkey;
     int recid = 0;
 
     /* Generate a random key and message. */
     {
-        secp256k1_scalar_t msg, key;
+        secp256k1_scalar msg, key;
         random_scalar_order_test(&msg);
         random_scalar_order_test(&key);
         secp256k1_scalar_get_b32(privkey, &key);
@@ -83,7 +83,7 @@ void test_ecdsa_recovery_edge_cases(void) {
         0x7D, 0xD7, 0x3E, 0x38, 0x7E, 0xE4, 0xFC, 0x86,
         0x6E, 0x1B, 0xE8, 0xEC, 0xC7, 0xDD, 0x95, 0x57
     };
-    secp256k1_pubkey_t pubkey;
+    secp256k1_pubkey pubkey;
     /* signature (r,s) = (4,4), which can be recovered with all 4 recids. */
     const unsigned char sigb64[64] = {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -95,9 +95,9 @@ void test_ecdsa_recovery_edge_cases(void) {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
     };
-    secp256k1_pubkey_t pubkeyb;
-    secp256k1_ecdsa_recoverable_signature_t rsig;
-    secp256k1_ecdsa_signature_t sig;
+    secp256k1_pubkey pubkeyb;
+    secp256k1_ecdsa_recoverable_signature rsig;
+    secp256k1_ecdsa_signature sig;
     int recid;
 
     CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sig64, 0));
@@ -157,7 +157,7 @@ void test_ecdsa_recovery_edge_cases(void) {
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigbder, sizeof(sigbder)) == 1);
         CHECK(secp256k1_ecdsa_verify(ctx, &sig, msg32, &pubkeyb) == 1);
         for (recid2 = 0; recid2 < 4; recid2++) {
-            secp256k1_pubkey_t pubkey2b;
+            secp256k1_pubkey pubkey2b;
             CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigb64, recid2) == 1);
             CHECK(secp256k1_ecdsa_recover(ctx, &pubkey2b, &rsig, msg32) == 1);
             /* Verifying with (order + r,4) should always fail. */
@@ -216,7 +216,7 @@ void test_ecdsa_recovery_edge_cases(void) {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
         };
-        secp256k1_pubkey_t pubkeyc;
+        secp256k1_pubkey pubkeyc;
         CHECK(secp256k1_ecdsa_recoverable_signature_parse_compact(ctx, &rsig, sigc64, 0) == 1);
         CHECK(secp256k1_ecdsa_recover(ctx, &pubkeyc, &rsig, msg32) == 1);
         CHECK(secp256k1_ecdsa_signature_parse_der(ctx, &sig, sigcder, sizeof(sigcder)) == 1);

--- a/src/modules/schnorr/main_impl.h
+++ b/src/modules/schnorr/main_impl.h
@@ -19,8 +19,8 @@ static void secp256k1_schnorr_msghash_sha256(unsigned char *h32, const unsigned 
 
 static const unsigned char secp256k1_schnorr_algo16[16] = "Schnorr+SHA256  ";
 
-int secp256k1_schnorr_sign(const secp256k1_context_t* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function_t noncefp, const void* noncedata) {
-    secp256k1_scalar_t sec, non;
+int secp256k1_schnorr_sign(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
+    secp256k1_scalar sec, non;
     int ret = 0;
     int overflow = 0;
     unsigned int count = 0;
@@ -57,8 +57,8 @@ int secp256k1_schnorr_sign(const secp256k1_context_t* ctx, unsigned char *sig64,
     return ret;
 }
 
-int secp256k1_schnorr_verify(const secp256k1_context_t* ctx, const unsigned char *sig64, const unsigned char *msg32, const secp256k1_pubkey_t *pubkey) {
-    secp256k1_ge_t q;
+int secp256k1_schnorr_verify(const secp256k1_context* ctx, const unsigned char *sig64, const unsigned char *msg32, const secp256k1_pubkey *pubkey) {
+    secp256k1_ge q;
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
     ARG_CHECK(msg32 != NULL);
@@ -69,8 +69,8 @@ int secp256k1_schnorr_verify(const secp256k1_context_t* ctx, const unsigned char
     return secp256k1_schnorr_sig_verify(&ctx->ecmult_ctx, sig64, &q, secp256k1_schnorr_msghash_sha256, msg32);
 }
 
-int secp256k1_schnorr_recover(const secp256k1_context_t* ctx, secp256k1_pubkey_t *pubkey, const unsigned char *sig64, const unsigned char *msg32) {
-    secp256k1_ge_t q;
+int secp256k1_schnorr_recover(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *sig64, const unsigned char *msg32) {
+    secp256k1_ge q;
 
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
@@ -87,12 +87,12 @@ int secp256k1_schnorr_recover(const secp256k1_context_t* ctx, secp256k1_pubkey_t
     }
 }
 
-int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context_t* ctx, secp256k1_pubkey_t *pubnonce, unsigned char *privnonce32, const unsigned char *sec32, const unsigned char *msg32, secp256k1_nonce_function_t noncefp, const void* noncedata) {
+int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, unsigned char *privnonce32, const unsigned char *sec32, const unsigned char *msg32, secp256k1_nonce_function noncefp, const void* noncedata) {
     int count = 0;
     int ret = 1;
-    secp256k1_gej_t Qj;
-    secp256k1_ge_t Q;
-    secp256k1_scalar_t sec;
+    secp256k1_gej Qj;
+    secp256k1_ge Q;
+    secp256k1_scalar sec;
 
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
@@ -129,10 +129,10 @@ int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context_t* ctx, secp25
     return ret;
 }
 
-int secp256k1_schnorr_partial_sign(const secp256k1_context_t* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *sec32, const secp256k1_pubkey_t *pubnonce_others, const unsigned char *secnonce32) {
+int secp256k1_schnorr_partial_sign(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *sec32, const secp256k1_pubkey *pubnonce_others, const unsigned char *secnonce32) {
     int overflow = 0;
-    secp256k1_scalar_t sec, non;
-    secp256k1_ge_t pubnon;
+    secp256k1_scalar sec, non;
+    secp256k1_ge pubnon;
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     ARG_CHECK(msg32 != NULL);
@@ -153,7 +153,7 @@ int secp256k1_schnorr_partial_sign(const secp256k1_context_t* ctx, unsigned char
     return secp256k1_schnorr_sig_sign(&ctx->ecmult_gen_ctx, sig64, &sec, &non, &pubnon, secp256k1_schnorr_msghash_sha256, msg32);
 }
 
-int secp256k1_schnorr_partial_combine(const secp256k1_context_t* ctx, unsigned char *sig64, const unsigned char * const *sig64sin, int n) {
+int secp256k1_schnorr_partial_combine(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char * const *sig64sin, int n) {
     ARG_CHECK(sig64 != NULL);
     ARG_CHECK(n >= 1);
     ARG_CHECK(sig64sin != NULL);

--- a/src/modules/schnorr/schnorr.h
+++ b/src/modules/schnorr/schnorr.h
@@ -10,11 +10,11 @@
 #include "scalar.h"
 #include "group.h"
 
-typedef void (*secp256k1_schnorr_msghash_t)(unsigned char *h32, const unsigned char *r32, const unsigned char *msg32);
+typedef void (*secp256k1_schnorr_msghash)(unsigned char *h32, const unsigned char *r32, const unsigned char *msg32);
 
-static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context_t* ctx, unsigned char *sig64, const secp256k1_scalar_t *key, const secp256k1_scalar_t *nonce, const secp256k1_ge_t *pubnonce, secp256k1_schnorr_msghash_t hash, const unsigned char *msg32);
-static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context_t* ctx, const unsigned char *sig64, const secp256k1_ge_t *pubkey, secp256k1_schnorr_msghash_t hash, const unsigned char *msg32);
-static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context_t* ctx, const unsigned char *sig64, secp256k1_ge_t *pubkey, secp256k1_schnorr_msghash_t hash, const unsigned char *msg32);
+static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context* ctx, unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar *nonce, const secp256k1_ge *pubnonce, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, const secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
 static int secp256k1_schnorr_sig_combine(unsigned char *sig64, int n, const unsigned char * const *sig64ins);
 
 #endif

--- a/src/modules/schnorr/schnorr_impl.h
+++ b/src/modules/schnorr/schnorr_impl.h
@@ -59,13 +59,13 @@
  *     Signature is valid if R + h * Q + s * G == 0.
  */
 
-static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context_t* ctx, unsigned char *sig64, const secp256k1_scalar_t *key, const secp256k1_scalar_t *nonce, const secp256k1_ge_t *pubnonce, secp256k1_schnorr_msghash_t hash, const unsigned char *msg32) {
-    secp256k1_gej_t Rj;
-    secp256k1_ge_t Ra;
+static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context* ctx, unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar *nonce, const secp256k1_ge *pubnonce, secp256k1_schnorr_msghash hash, const unsigned char *msg32) {
+    secp256k1_gej Rj;
+    secp256k1_ge Ra;
     unsigned char h32[32];
-    secp256k1_scalar_t h, s;
+    secp256k1_scalar h, s;
     int overflow;
-    secp256k1_scalar_t n;
+    secp256k1_scalar n;
 
     if (secp256k1_scalar_is_zero(key) || secp256k1_scalar_is_zero(nonce)) {
         return 0;
@@ -103,11 +103,11 @@ static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context_t* ctx,
     return 1;
 }
 
-static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context_t* ctx, const unsigned char *sig64, const secp256k1_ge_t *pubkey, secp256k1_schnorr_msghash_t hash, const unsigned char *msg32) {
-    secp256k1_gej_t Qj, Rj;
-    secp256k1_ge_t Ra;
-    secp256k1_fe_t Rx;
-    secp256k1_scalar_t h, s;
+static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, const secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32) {
+    secp256k1_gej Qj, Rj;
+    secp256k1_ge Ra;
+    secp256k1_fe Rx;
+    secp256k1_scalar h, s;
     unsigned char hh[32];
     int overflow;
 
@@ -141,11 +141,11 @@ static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context_t* ctx, c
     return secp256k1_fe_equal_var(&Rx, &Ra.x);
 }
 
-static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context_t* ctx, const unsigned char *sig64, secp256k1_ge_t *pubkey, secp256k1_schnorr_msghash_t hash, const unsigned char *msg32) {
-    secp256k1_gej_t Qj, Rj;
-    secp256k1_ge_t Ra;
-    secp256k1_fe_t Rx;
-    secp256k1_scalar_t h, s;
+static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32) {
+    secp256k1_gej Qj, Rj;
+    secp256k1_ge Ra;
+    secp256k1_fe Rx;
+    secp256k1_scalar h, s;
     unsigned char hh[32];
     int overflow;
 
@@ -179,10 +179,10 @@ static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context_t* ctx, 
 }
 
 static int secp256k1_schnorr_sig_combine(unsigned char *sig64, int n, const unsigned char * const *sig64ins) {
-    secp256k1_scalar_t s = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
+    secp256k1_scalar s = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
     int i;
     for (i = 0; i < n; i++) {
-        secp256k1_scalar_t si;
+        secp256k1_scalar si;
         int overflow;
         secp256k1_scalar_set_b32(&si, sig64ins[i] + 32, &overflow);
         if (overflow) {

--- a/src/modules/schnorr/tests_impl.h
+++ b/src/modules/schnorr/tests_impl.h
@@ -11,11 +11,11 @@ void test_schnorr_end_to_end(void) {
     unsigned char privkey[32];
     unsigned char message[32];
     unsigned char schnorr_signature[64];
-    secp256k1_pubkey_t pubkey, recpubkey;
+    secp256k1_pubkey pubkey, recpubkey;
 
     /* Generate a random key and message. */
     {
-        secp256k1_scalar_t key;
+        secp256k1_scalar key;
         random_scalar_order_test(&key);
         secp256k1_scalar_get_b32(privkey, &key);
         secp256k1_rand256_test(message);
@@ -48,9 +48,9 @@ void test_schnorr_hash(unsigned char *h32, const unsigned char *r32, const unsig
 void test_schnorr_sign_verify(void) {
     unsigned char msg32[32];
     unsigned char sig64[3][64];
-    secp256k1_gej_t pubkeyj[3];
-    secp256k1_ge_t pubkey[3];
-    secp256k1_scalar_t nonce[3], key[3];
+    secp256k1_gej pubkeyj[3];
+    secp256k1_ge pubkey[3];
+    secp256k1_scalar nonce[3], key[3];
     int i = 0;
     int k;
 
@@ -83,14 +83,14 @@ void test_schnorr_sign_verify(void) {
 void test_schnorr_threshold(void) {
     unsigned char msg[32];
     unsigned char sec[5][32];
-    secp256k1_pubkey_t pub[5];
+    secp256k1_pubkey pub[5];
     unsigned char nonce[5][32];
-    secp256k1_pubkey_t pubnonce[5];
+    secp256k1_pubkey pubnonce[5];
     unsigned char sig[5][64];
     const unsigned char* sigs[5];
     unsigned char allsig[64];
-    const secp256k1_pubkey_t* pubs[5];
-    secp256k1_pubkey_t allpub;
+    const secp256k1_pubkey* pubs[5];
+    secp256k1_pubkey allpub;
     int n, i;
     int damage;
     int ret = 0;
@@ -112,8 +112,8 @@ void test_schnorr_threshold(void) {
         sec[secp256k1_rand32() % n][secp256k1_rand32() % 32] ^= 1 + (secp256k1_rand32() % 255);
     }
     for (i = 0; i < n; i++) {
-        secp256k1_pubkey_t allpubnonce;
-        const secp256k1_pubkey_t *pubnonces[4];
+        secp256k1_pubkey allpubnonce;
+        const secp256k1_pubkey *pubnonces[4];
         int j;
         for (j = 0; j < i; j++) {
             pubnonces[j] = &pubnonce[j];
@@ -144,7 +144,7 @@ void test_schnorr_threshold(void) {
 void test_schnorr_recovery(void) {
     unsigned char msg32[32];
     unsigned char sig64[64];
-    secp256k1_ge_t Q;
+    secp256k1_ge Q;
 
     secp256k1_rand256_test(msg32);
     secp256k1_rand256_test(sig64);

--- a/src/num.h
+++ b/src/num.h
@@ -20,48 +20,48 @@
 #endif
 
 /** Copy a number. */
-static void secp256k1_num_copy(secp256k1_num_t *r, const secp256k1_num_t *a);
+static void secp256k1_num_copy(secp256k1_num *r, const secp256k1_num *a);
 
 /** Convert a number's absolute value to a binary big-endian string.
  *  There must be enough place. */
-static void secp256k1_num_get_bin(unsigned char *r, unsigned int rlen, const secp256k1_num_t *a);
+static void secp256k1_num_get_bin(unsigned char *r, unsigned int rlen, const secp256k1_num *a);
 
 /** Set a number to the value of a binary big-endian string. */
-static void secp256k1_num_set_bin(secp256k1_num_t *r, const unsigned char *a, unsigned int alen);
+static void secp256k1_num_set_bin(secp256k1_num *r, const unsigned char *a, unsigned int alen);
 
 /** Compute a modular inverse. The input must be less than the modulus. */
-static void secp256k1_num_mod_inverse(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *m);
+static void secp256k1_num_mod_inverse(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *m);
 
 /** Compare the absolute value of two numbers. */
-static int secp256k1_num_cmp(const secp256k1_num_t *a, const secp256k1_num_t *b);
+static int secp256k1_num_cmp(const secp256k1_num *a, const secp256k1_num *b);
 
 /** Test whether two number are equal (including sign). */
-static int secp256k1_num_eq(const secp256k1_num_t *a, const secp256k1_num_t *b);
+static int secp256k1_num_eq(const secp256k1_num *a, const secp256k1_num *b);
 
 /** Add two (signed) numbers. */
-static void secp256k1_num_add(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b);
+static void secp256k1_num_add(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b);
 
 /** Subtract two (signed) numbers. */
-static void secp256k1_num_sub(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b);
+static void secp256k1_num_sub(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b);
 
 /** Multiply two (signed) numbers. */
-static void secp256k1_num_mul(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b);
+static void secp256k1_num_mul(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b);
 
 /** Replace a number by its remainder modulo m. M's sign is ignored. The result is a number between 0 and m-1,
     even if r was negative. */
-static void secp256k1_num_mod(secp256k1_num_t *r, const secp256k1_num_t *m);
+static void secp256k1_num_mod(secp256k1_num *r, const secp256k1_num *m);
 
 /** Right-shift the passed number by bits bits. */
-static void secp256k1_num_shift(secp256k1_num_t *r, int bits);
+static void secp256k1_num_shift(secp256k1_num *r, int bits);
 
 /** Check whether a number is zero. */
-static int secp256k1_num_is_zero(const secp256k1_num_t *a);
+static int secp256k1_num_is_zero(const secp256k1_num *a);
 
 /** Check whether a number is strictly negative. */
-static int secp256k1_num_is_neg(const secp256k1_num_t *a);
+static int secp256k1_num_is_neg(const secp256k1_num *a);
 
 /** Change a number's sign. */
-static void secp256k1_num_negate(secp256k1_num_t *r);
+static void secp256k1_num_negate(secp256k1_num *r);
 
 #endif
 

--- a/src/num_gmp.h
+++ b/src/num_gmp.h
@@ -15,6 +15,6 @@ typedef struct {
     mp_limb_t data[2*NUM_LIMBS];
     int neg;
     int limbs;
-} secp256k1_num_t;
+} secp256k1_num;
 
 #endif

--- a/src/num_gmp_impl.h
+++ b/src/num_gmp_impl.h
@@ -15,18 +15,18 @@
 #include "num.h"
 
 #ifdef VERIFY
-static void secp256k1_num_sanity(const secp256k1_num_t *a) {
+static void secp256k1_num_sanity(const secp256k1_num *a) {
     VERIFY_CHECK(a->limbs == 1 || (a->limbs > 1 && a->data[a->limbs-1] != 0));
 }
 #else
 #define secp256k1_num_sanity(a) do { } while(0)
 #endif
 
-static void secp256k1_num_copy(secp256k1_num_t *r, const secp256k1_num_t *a) {
+static void secp256k1_num_copy(secp256k1_num *r, const secp256k1_num *a) {
     *r = *a;
 }
 
-static void secp256k1_num_get_bin(unsigned char *r, unsigned int rlen, const secp256k1_num_t *a) {
+static void secp256k1_num_get_bin(unsigned char *r, unsigned int rlen, const secp256k1_num *a) {
     unsigned char tmp[65];
     int len = 0;
     int shift = 0;
@@ -42,7 +42,7 @@ static void secp256k1_num_get_bin(unsigned char *r, unsigned int rlen, const sec
     memset(tmp, 0, sizeof(tmp));
 }
 
-static void secp256k1_num_set_bin(secp256k1_num_t *r, const unsigned char *a, unsigned int alen) {
+static void secp256k1_num_set_bin(secp256k1_num *r, const unsigned char *a, unsigned int alen) {
     int len;
     VERIFY_CHECK(alen > 0);
     VERIFY_CHECK(alen <= 64);
@@ -59,7 +59,7 @@ static void secp256k1_num_set_bin(secp256k1_num_t *r, const unsigned char *a, un
     }
 }
 
-static void secp256k1_num_add_abs(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b) {
+static void secp256k1_num_add_abs(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
     mp_limb_t c = mpn_add(r->data, a->data, a->limbs, b->data, b->limbs);
     r->limbs = a->limbs;
     if (c != 0) {
@@ -68,7 +68,7 @@ static void secp256k1_num_add_abs(secp256k1_num_t *r, const secp256k1_num_t *a, 
     }
 }
 
-static void secp256k1_num_sub_abs(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b) {
+static void secp256k1_num_sub_abs(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
     mp_limb_t c = mpn_sub(r->data, a->data, a->limbs, b->data, b->limbs);
     VERIFY_CHECK(c == 0);
     r->limbs = a->limbs;
@@ -77,7 +77,7 @@ static void secp256k1_num_sub_abs(secp256k1_num_t *r, const secp256k1_num_t *a, 
     }
 }
 
-static void secp256k1_num_mod(secp256k1_num_t *r, const secp256k1_num_t *m) {
+static void secp256k1_num_mod(secp256k1_num *r, const secp256k1_num *m) {
     secp256k1_num_sanity(r);
     secp256k1_num_sanity(m);
 
@@ -97,7 +97,7 @@ static void secp256k1_num_mod(secp256k1_num_t *r, const secp256k1_num_t *m) {
     }
 }
 
-static void secp256k1_num_mod_inverse(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *m) {
+static void secp256k1_num_mod_inverse(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *m) {
     int i;
     mp_limb_t g[NUM_LIMBS+1];
     mp_limb_t u[NUM_LIMBS+1];
@@ -142,15 +142,15 @@ static void secp256k1_num_mod_inverse(secp256k1_num_t *r, const secp256k1_num_t 
     memset(v, 0, sizeof(v));
 }
 
-static int secp256k1_num_is_zero(const secp256k1_num_t *a) {
+static int secp256k1_num_is_zero(const secp256k1_num *a) {
     return (a->limbs == 1 && a->data[0] == 0);
 }
 
-static int secp256k1_num_is_neg(const secp256k1_num_t *a) {
+static int secp256k1_num_is_neg(const secp256k1_num *a) {
     return (a->limbs > 1 || a->data[0] != 0) && a->neg;
 }
 
-static int secp256k1_num_cmp(const secp256k1_num_t *a, const secp256k1_num_t *b) {
+static int secp256k1_num_cmp(const secp256k1_num *a, const secp256k1_num *b) {
     if (a->limbs > b->limbs) {
         return 1;
     }
@@ -160,7 +160,7 @@ static int secp256k1_num_cmp(const secp256k1_num_t *a, const secp256k1_num_t *b)
     return mpn_cmp(a->data, b->data, a->limbs);
 }
 
-static int secp256k1_num_eq(const secp256k1_num_t *a, const secp256k1_num_t *b) {
+static int secp256k1_num_eq(const secp256k1_num *a, const secp256k1_num *b) {
     if (a->limbs > b->limbs) {
         return 0;
     }
@@ -173,7 +173,7 @@ static int secp256k1_num_eq(const secp256k1_num_t *a, const secp256k1_num_t *b) 
     return mpn_cmp(a->data, b->data, a->limbs) == 0;
 }
 
-static void secp256k1_num_subadd(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b, int bneg) {
+static void secp256k1_num_subadd(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b, int bneg) {
     if (!(b->neg ^ bneg ^ a->neg)) { /* a and b have the same sign */
         r->neg = a->neg;
         if (a->limbs >= b->limbs) {
@@ -192,19 +192,19 @@ static void secp256k1_num_subadd(secp256k1_num_t *r, const secp256k1_num_t *a, c
     }
 }
 
-static void secp256k1_num_add(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b) {
+static void secp256k1_num_add(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
     secp256k1_num_sanity(a);
     secp256k1_num_sanity(b);
     secp256k1_num_subadd(r, a, b, 0);
 }
 
-static void secp256k1_num_sub(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b) {
+static void secp256k1_num_sub(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
     secp256k1_num_sanity(a);
     secp256k1_num_sanity(b);
     secp256k1_num_subadd(r, a, b, 1);
 }
 
-static void secp256k1_num_mul(secp256k1_num_t *r, const secp256k1_num_t *a, const secp256k1_num_t *b) {
+static void secp256k1_num_mul(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
     mp_limb_t tmp[2*NUM_LIMBS+1];
     secp256k1_num_sanity(a);
     secp256k1_num_sanity(b);
@@ -231,7 +231,7 @@ static void secp256k1_num_mul(secp256k1_num_t *r, const secp256k1_num_t *a, cons
     memset(tmp, 0, sizeof(tmp));
 }
 
-static void secp256k1_num_shift(secp256k1_num_t *r, int bits) {
+static void secp256k1_num_shift(secp256k1_num *r, int bits) {
     int i;
     if (bits % GMP_NUMB_BITS) {
         /* Shift within limbs. */
@@ -253,7 +253,7 @@ static void secp256k1_num_shift(secp256k1_num_t *r, int bits) {
     }
 }
 
-static void secp256k1_num_negate(secp256k1_num_t *r) {
+static void secp256k1_num_negate(secp256k1_num *r) {
     r->neg ^= 1;
 }
 

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -22,83 +22,83 @@
 #endif
 
 /** Clear a scalar to prevent the leak of sensitive data. */
-static void secp256k1_scalar_clear(secp256k1_scalar_t *r);
+static void secp256k1_scalar_clear(secp256k1_scalar *r);
 
 /** Access bits from a scalar. All requested bits must belong to the same 32-bit limb. */
-static unsigned int secp256k1_scalar_get_bits(const secp256k1_scalar_t *a, unsigned int offset, unsigned int count);
+static unsigned int secp256k1_scalar_get_bits(const secp256k1_scalar *a, unsigned int offset, unsigned int count);
 
 /** Access bits from a scalar. Not constant time. */
-static unsigned int secp256k1_scalar_get_bits_var(const secp256k1_scalar_t *a, unsigned int offset, unsigned int count);
+static unsigned int secp256k1_scalar_get_bits_var(const secp256k1_scalar *a, unsigned int offset, unsigned int count);
 
 /** Set a scalar from a big endian byte array. */
-static void secp256k1_scalar_set_b32(secp256k1_scalar_t *r, const unsigned char *bin, int *overflow);
+static void secp256k1_scalar_set_b32(secp256k1_scalar *r, const unsigned char *bin, int *overflow);
 
 /** Set a scalar to an unsigned integer. */
-static void secp256k1_scalar_set_int(secp256k1_scalar_t *r, unsigned int v);
+static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v);
 
 /** Convert a scalar to a byte array. */
-static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar_t* a);
+static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar* a);
 
 /** Add two scalars together (modulo the group order). Returns whether it overflowed. */
-static int secp256k1_scalar_add(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b);
+static int secp256k1_scalar_add(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b);
 
 /** Conditionally add a power of two to a scalar. The result is not allowed to overflow. */
-static void secp256k1_scalar_cadd_bit(secp256k1_scalar_t *r, unsigned int bit, int flag);
+static void secp256k1_scalar_cadd_bit(secp256k1_scalar *r, unsigned int bit, int flag);
 
 /** Multiply two scalars (modulo the group order). */
-static void secp256k1_scalar_mul(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b);
+static void secp256k1_scalar_mul(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b);
 
 /** Shift a scalar right by some amount strictly between 0 and 16, returning
  *  the low bits that were shifted off */
-static int secp256k1_scalar_shr_int(secp256k1_scalar_t *r, int n);
+static int secp256k1_scalar_shr_int(secp256k1_scalar *r, int n);
 
 /** Compute the square of a scalar (modulo the group order). */
-static void secp256k1_scalar_sqr(secp256k1_scalar_t *r, const secp256k1_scalar_t *a);
+static void secp256k1_scalar_sqr(secp256k1_scalar *r, const secp256k1_scalar *a);
 
 /** Compute the inverse of a scalar (modulo the group order). */
-static void secp256k1_scalar_inverse(secp256k1_scalar_t *r, const secp256k1_scalar_t *a);
+static void secp256k1_scalar_inverse(secp256k1_scalar *r, const secp256k1_scalar *a);
 
 /** Compute the inverse of a scalar (modulo the group order), without constant-time guarantee. */
-static void secp256k1_scalar_inverse_var(secp256k1_scalar_t *r, const secp256k1_scalar_t *a);
+static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_scalar *a);
 
 /** Compute the complement of a scalar (modulo the group order). */
-static void secp256k1_scalar_negate(secp256k1_scalar_t *r, const secp256k1_scalar_t *a);
+static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar *a);
 
 /** Check whether a scalar equals zero. */
-static int secp256k1_scalar_is_zero(const secp256k1_scalar_t *a);
+static int secp256k1_scalar_is_zero(const secp256k1_scalar *a);
 
 /** Check whether a scalar equals one. */
-static int secp256k1_scalar_is_one(const secp256k1_scalar_t *a);
+static int secp256k1_scalar_is_one(const secp256k1_scalar *a);
 
 /** Check whether a scalar, considered as an nonnegative integer, is even. */
-static int secp256k1_scalar_is_even(const secp256k1_scalar_t *a);
+static int secp256k1_scalar_is_even(const secp256k1_scalar *a);
 
 /** Check whether a scalar is higher than the group order divided by 2. */
-static int secp256k1_scalar_is_high(const secp256k1_scalar_t *a);
+static int secp256k1_scalar_is_high(const secp256k1_scalar *a);
 
 /** Conditionally negate a number, in constant time.
  * Returns -1 if the number was negated, 1 otherwise */
-static int secp256k1_scalar_cond_negate(secp256k1_scalar_t *a, int flag);
+static int secp256k1_scalar_cond_negate(secp256k1_scalar *a, int flag);
 
 #ifndef USE_NUM_NONE
 /** Convert a scalar to a number. */
-static void secp256k1_scalar_get_num(secp256k1_num_t *r, const secp256k1_scalar_t *a);
+static void secp256k1_scalar_get_num(secp256k1_num *r, const secp256k1_scalar *a);
 
 /** Get the order of the group as a number. */
-static void secp256k1_scalar_order_get_num(secp256k1_num_t *r);
+static void secp256k1_scalar_order_get_num(secp256k1_num *r);
 #endif
 
 /** Compare two scalars. */
-static int secp256k1_scalar_eq(const secp256k1_scalar_t *a, const secp256k1_scalar_t *b);
+static int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b);
 
 #ifdef USE_ENDOMORPHISM
 /** Find r1 and r2 such that r1+r2*2^128 = a. */
-static void secp256k1_scalar_split_128(secp256k1_scalar_t *r1, secp256k1_scalar_t *r2, const secp256k1_scalar_t *a);
+static void secp256k1_scalar_split_128(secp256k1_scalar *r1, secp256k1_scalar *r2, const secp256k1_scalar *a);
 /** Find r1 and r2 such that r1+r2*lambda = a, and r1 and r2 are maximum 128 bits long (see secp256k1_gej_mul_lambda). */
-static void secp256k1_scalar_split_lambda(secp256k1_scalar_t *r1, secp256k1_scalar_t *r2, const secp256k1_scalar_t *a);
+static void secp256k1_scalar_split_lambda(secp256k1_scalar *r1, secp256k1_scalar *r2, const secp256k1_scalar *a);
 #endif
 
 /** Multiply a and b (without taking the modulus!), divide by 2**shift, and round to the nearest integer. Shift must be at least 256. */
-static void secp256k1_scalar_mul_shift_var(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b, unsigned int shift);
+static void secp256k1_scalar_mul_shift_var(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b, unsigned int shift);
 
 #endif

--- a/src/scalar_4x64.h
+++ b/src/scalar_4x64.h
@@ -12,7 +12,7 @@
 /** A scalar modulo the group order of the secp256k1 curve. */
 typedef struct {
     uint64_t d[4];
-} secp256k1_scalar_t;
+} secp256k1_scalar;
 
 #define SECP256K1_SCALAR_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{((uint64_t)(d1)) << 32 | (d0), ((uint64_t)(d3)) << 32 | (d2), ((uint64_t)(d5)) << 32 | (d4), ((uint64_t)(d7)) << 32 | (d6)}}
 

--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -24,26 +24,26 @@
 #define SECP256K1_N_H_2 ((uint64_t)0xFFFFFFFFFFFFFFFFULL)
 #define SECP256K1_N_H_3 ((uint64_t)0x7FFFFFFFFFFFFFFFULL)
 
-SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar_t *r) {
+SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) {
     r->d[0] = 0;
     r->d[1] = 0;
     r->d[2] = 0;
     r->d[3] = 0;
 }
 
-SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar_t *r, unsigned int v) {
+SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v) {
     r->d[0] = v;
     r->d[1] = 0;
     r->d[2] = 0;
     r->d[3] = 0;
 }
 
-SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits(const secp256k1_scalar_t *a, unsigned int offset, unsigned int count) {
+SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits(const secp256k1_scalar *a, unsigned int offset, unsigned int count) {
     VERIFY_CHECK((offset + count - 1) >> 6 == offset >> 6);
     return (a->d[offset >> 6] >> (offset & 0x3F)) & ((((uint64_t)1) << count) - 1);
 }
 
-SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits_var(const secp256k1_scalar_t *a, unsigned int offset, unsigned int count) {
+SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits_var(const secp256k1_scalar *a, unsigned int offset, unsigned int count) {
     VERIFY_CHECK(count < 32);
     VERIFY_CHECK(offset + count <= 256);
     if ((offset + count - 1) >> 6 == offset >> 6) {
@@ -54,7 +54,7 @@ SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits_var(const secp256
     }
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scalar_t *a) {
+SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     no |= (a->d[3] < SECP256K1_N_3); /* No need for a > check. */
@@ -66,7 +66,7 @@ SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scal
     return yes;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar_t *r, unsigned int overflow) {
+SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar *r, unsigned int overflow) {
     uint128_t t;
     VERIFY_CHECK(overflow <= 1);
     t = (uint128_t)r->d[0] + overflow * SECP256K1_N_C_0;
@@ -80,7 +80,7 @@ SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar_t *r, unsig
     return overflow;
 }
 
-static int secp256k1_scalar_add(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+static int secp256k1_scalar_add(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b) {
     int overflow;
     uint128_t t = (uint128_t)a->d[0] + b->d[0];
     r->d[0] = t & 0xFFFFFFFFFFFFFFFFULL; t >>= 64;
@@ -96,7 +96,7 @@ static int secp256k1_scalar_add(secp256k1_scalar_t *r, const secp256k1_scalar_t 
     return overflow;
 }
 
-static void secp256k1_scalar_cadd_bit(secp256k1_scalar_t *r, unsigned int bit, int flag) {
+static void secp256k1_scalar_cadd_bit(secp256k1_scalar *r, unsigned int bit, int flag) {
     uint128_t t;
     VERIFY_CHECK(bit < 256);
     bit += ((uint32_t) flag - 1) & 0x100;  /* forcing (bit >> 6) > 3 makes this a noop */
@@ -114,7 +114,7 @@ static void secp256k1_scalar_cadd_bit(secp256k1_scalar_t *r, unsigned int bit, i
 #endif
 }
 
-static void secp256k1_scalar_set_b32(secp256k1_scalar_t *r, const unsigned char *b32, int *overflow) {
+static void secp256k1_scalar_set_b32(secp256k1_scalar *r, const unsigned char *b32, int *overflow) {
     int over;
     r->d[0] = (uint64_t)b32[31] | (uint64_t)b32[30] << 8 | (uint64_t)b32[29] << 16 | (uint64_t)b32[28] << 24 | (uint64_t)b32[27] << 32 | (uint64_t)b32[26] << 40 | (uint64_t)b32[25] << 48 | (uint64_t)b32[24] << 56;
     r->d[1] = (uint64_t)b32[23] | (uint64_t)b32[22] << 8 | (uint64_t)b32[21] << 16 | (uint64_t)b32[20] << 24 | (uint64_t)b32[19] << 32 | (uint64_t)b32[18] << 40 | (uint64_t)b32[17] << 48 | (uint64_t)b32[16] << 56;
@@ -126,18 +126,18 @@ static void secp256k1_scalar_set_b32(secp256k1_scalar_t *r, const unsigned char 
     }
 }
 
-static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar_t* a) {
+static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar* a) {
     bin[0] = a->d[3] >> 56; bin[1] = a->d[3] >> 48; bin[2] = a->d[3] >> 40; bin[3] = a->d[3] >> 32; bin[4] = a->d[3] >> 24; bin[5] = a->d[3] >> 16; bin[6] = a->d[3] >> 8; bin[7] = a->d[3];
     bin[8] = a->d[2] >> 56; bin[9] = a->d[2] >> 48; bin[10] = a->d[2] >> 40; bin[11] = a->d[2] >> 32; bin[12] = a->d[2] >> 24; bin[13] = a->d[2] >> 16; bin[14] = a->d[2] >> 8; bin[15] = a->d[2];
     bin[16] = a->d[1] >> 56; bin[17] = a->d[1] >> 48; bin[18] = a->d[1] >> 40; bin[19] = a->d[1] >> 32; bin[20] = a->d[1] >> 24; bin[21] = a->d[1] >> 16; bin[22] = a->d[1] >> 8; bin[23] = a->d[1];
     bin[24] = a->d[0] >> 56; bin[25] = a->d[0] >> 48; bin[26] = a->d[0] >> 40; bin[27] = a->d[0] >> 32; bin[28] = a->d[0] >> 24; bin[29] = a->d[0] >> 16; bin[30] = a->d[0] >> 8; bin[31] = a->d[0];
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar_t *a) {
+SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
     return (a->d[0] | a->d[1] | a->d[2] | a->d[3]) == 0;
 }
 
-static void secp256k1_scalar_negate(secp256k1_scalar_t *r, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar *a) {
     uint64_t nonzero = 0xFFFFFFFFFFFFFFFFULL * (secp256k1_scalar_is_zero(a) == 0);
     uint128_t t = (uint128_t)(~a->d[0]) + SECP256K1_N_0 + 1;
     r->d[0] = t & nonzero; t >>= 64;
@@ -149,11 +149,11 @@ static void secp256k1_scalar_negate(secp256k1_scalar_t *r, const secp256k1_scala
     r->d[3] = t & nonzero;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar_t *a) {
+SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
     return ((a->d[0] ^ 1) | a->d[1] | a->d[2] | a->d[3]) == 0;
 }
 
-static int secp256k1_scalar_is_high(const secp256k1_scalar_t *a) {
+static int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     no |= (a->d[3] < SECP256K1_N_H_3);
@@ -165,7 +165,7 @@ static int secp256k1_scalar_is_high(const secp256k1_scalar_t *a) {
     return yes;
 }
 
-static int secp256k1_scalar_cond_negate(secp256k1_scalar_t *r, int flag) {
+static int secp256k1_scalar_cond_negate(secp256k1_scalar *r, int flag) {
     /* If we are flag = 0, mask = 00...00 and this is a no-op;
      * if we are flag = 1, mask = 11...11 and this is identical to secp256k1_scalar_negate */
     uint64_t mask = !flag - 1;
@@ -267,7 +267,7 @@ static int secp256k1_scalar_cond_negate(secp256k1_scalar_t *r, int flag) {
     VERIFY_CHECK(c2 == 0); \
 }
 
-static void secp256k1_scalar_reduce_512(secp256k1_scalar_t *r, const uint64_t *l) {
+static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint64_t *l) {
 #ifdef USE_ASM_X86_64
     /* Reduce 512 bits into 385. */
     uint64_t m0, m1, m2, m3, m4, m5, m6;
@@ -576,7 +576,7 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar_t *r, const uint64_t *l
     secp256k1_scalar_reduce(r, c + secp256k1_scalar_check_overflow(r));
 }
 
-static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar *a, const secp256k1_scalar *b) {
 #ifdef USE_ASM_X86_64
     const uint64_t *pb = b->d;
     __asm__ __volatile__(
@@ -743,7 +743,7 @@ static void secp256k1_scalar_mul_512(uint64_t l[8], const secp256k1_scalar_t *a,
 #endif
 }
 
-static void secp256k1_scalar_sqr_512(uint64_t l[8], const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_sqr_512(uint64_t l[8], const secp256k1_scalar *a) {
 #ifdef USE_ASM_X86_64
     __asm__ __volatile__(
     /* Preload */
@@ -888,13 +888,13 @@ static void secp256k1_scalar_sqr_512(uint64_t l[8], const secp256k1_scalar_t *a)
 #undef extract
 #undef extract_fast
 
-static void secp256k1_scalar_mul(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+static void secp256k1_scalar_mul(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b) {
     uint64_t l[8];
     secp256k1_scalar_mul_512(l, a, b);
     secp256k1_scalar_reduce_512(r, l);
 }
 
-static int secp256k1_scalar_shr_int(secp256k1_scalar_t *r, int n) {
+static int secp256k1_scalar_shr_int(secp256k1_scalar *r, int n) {
     int ret;
     VERIFY_CHECK(n > 0);
     VERIFY_CHECK(n < 16);
@@ -906,13 +906,13 @@ static int secp256k1_scalar_shr_int(secp256k1_scalar_t *r, int n) {
     return ret;
 }
 
-static void secp256k1_scalar_sqr(secp256k1_scalar_t *r, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_sqr(secp256k1_scalar *r, const secp256k1_scalar *a) {
     uint64_t l[8];
     secp256k1_scalar_sqr_512(l, a);
     secp256k1_scalar_reduce_512(r, l);
 }
 
-static void secp256k1_scalar_split_128(secp256k1_scalar_t *r1, secp256k1_scalar_t *r2, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_split_128(secp256k1_scalar *r1, secp256k1_scalar *r2, const secp256k1_scalar *a) {
     r1->d[0] = a->d[0];
     r1->d[1] = a->d[1];
     r1->d[2] = 0;
@@ -923,11 +923,11 @@ static void secp256k1_scalar_split_128(secp256k1_scalar_t *r1, secp256k1_scalar_
     r2->d[3] = 0;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
     return ((a->d[0] ^ b->d[0]) | (a->d[1] ^ b->d[1]) | (a->d[2] ^ b->d[2]) | (a->d[3] ^ b->d[3])) == 0;
 }
 
-SECP256K1_INLINE static void secp256k1_scalar_mul_shift_var(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b, unsigned int shift) {
+SECP256K1_INLINE static void secp256k1_scalar_mul_shift_var(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b, unsigned int shift) {
     uint64_t l[8];
     unsigned int shiftlimbs;
     unsigned int shiftlow;

--- a/src/scalar_8x32.h
+++ b/src/scalar_8x32.h
@@ -12,7 +12,7 @@
 /** A scalar modulo the group order of the secp256k1 curve. */
 typedef struct {
     uint32_t d[8];
-} secp256k1_scalar_t;
+} secp256k1_scalar;
 
 #define SECP256K1_SCALAR_CONST(d7, d6, d5, d4, d3, d2, d1, d0) {{(d0), (d1), (d2), (d3), (d4), (d5), (d6), (d7)}}
 

--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -34,7 +34,7 @@
 #define SECP256K1_N_H_6 ((uint32_t)0xFFFFFFFFUL)
 #define SECP256K1_N_H_7 ((uint32_t)0x7FFFFFFFUL)
 
-SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar_t *r) {
+SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar *r) {
     r->d[0] = 0;
     r->d[1] = 0;
     r->d[2] = 0;
@@ -45,7 +45,7 @@ SECP256K1_INLINE static void secp256k1_scalar_clear(secp256k1_scalar_t *r) {
     r->d[7] = 0;
 }
 
-SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar_t *r, unsigned int v) {
+SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar *r, unsigned int v) {
     r->d[0] = v;
     r->d[1] = 0;
     r->d[2] = 0;
@@ -56,12 +56,12 @@ SECP256K1_INLINE static void secp256k1_scalar_set_int(secp256k1_scalar_t *r, uns
     r->d[7] = 0;
 }
 
-SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits(const secp256k1_scalar_t *a, unsigned int offset, unsigned int count) {
+SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits(const secp256k1_scalar *a, unsigned int offset, unsigned int count) {
     VERIFY_CHECK((offset + count - 1) >> 5 == offset >> 5);
     return (a->d[offset >> 5] >> (offset & 0x1F)) & ((1 << count) - 1);
 }
 
-SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits_var(const secp256k1_scalar_t *a, unsigned int offset, unsigned int count) {
+SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits_var(const secp256k1_scalar *a, unsigned int offset, unsigned int count) {
     VERIFY_CHECK(count < 32);
     VERIFY_CHECK(offset + count <= 256);
     if ((offset + count - 1) >> 5 == offset >> 5) {
@@ -72,7 +72,7 @@ SECP256K1_INLINE static unsigned int secp256k1_scalar_get_bits_var(const secp256
     }
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scalar_t *a) {
+SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     no |= (a->d[7] < SECP256K1_N_7); /* No need for a > check. */
@@ -90,7 +90,7 @@ SECP256K1_INLINE static int secp256k1_scalar_check_overflow(const secp256k1_scal
     return yes;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar_t *r, uint32_t overflow) {
+SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar *r, uint32_t overflow) {
     uint64_t t;
     VERIFY_CHECK(overflow <= 1);
     t = (uint64_t)r->d[0] + overflow * SECP256K1_N_C_0;
@@ -112,7 +112,7 @@ SECP256K1_INLINE static int secp256k1_scalar_reduce(secp256k1_scalar_t *r, uint3
     return overflow;
 }
 
-static int secp256k1_scalar_add(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+static int secp256k1_scalar_add(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b) {
     int overflow;
     uint64_t t = (uint64_t)a->d[0] + b->d[0];
     r->d[0] = t & 0xFFFFFFFFULL; t >>= 32;
@@ -136,7 +136,7 @@ static int secp256k1_scalar_add(secp256k1_scalar_t *r, const secp256k1_scalar_t 
     return overflow;
 }
 
-static void secp256k1_scalar_cadd_bit(secp256k1_scalar_t *r, unsigned int bit, int flag) {
+static void secp256k1_scalar_cadd_bit(secp256k1_scalar *r, unsigned int bit, int flag) {
     uint64_t t;
     VERIFY_CHECK(bit < 256);
     bit += ((uint32_t) flag - 1) & 0x100;  /* forcing (bit >> 5) > 7 makes this a noop */
@@ -162,7 +162,7 @@ static void secp256k1_scalar_cadd_bit(secp256k1_scalar_t *r, unsigned int bit, i
 #endif
 }
 
-static void secp256k1_scalar_set_b32(secp256k1_scalar_t *r, const unsigned char *b32, int *overflow) {
+static void secp256k1_scalar_set_b32(secp256k1_scalar *r, const unsigned char *b32, int *overflow) {
     int over;
     r->d[0] = (uint32_t)b32[31] | (uint32_t)b32[30] << 8 | (uint32_t)b32[29] << 16 | (uint32_t)b32[28] << 24;
     r->d[1] = (uint32_t)b32[27] | (uint32_t)b32[26] << 8 | (uint32_t)b32[25] << 16 | (uint32_t)b32[24] << 24;
@@ -178,7 +178,7 @@ static void secp256k1_scalar_set_b32(secp256k1_scalar_t *r, const unsigned char 
     }
 }
 
-static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar_t* a) {
+static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar* a) {
     bin[0] = a->d[7] >> 24; bin[1] = a->d[7] >> 16; bin[2] = a->d[7] >> 8; bin[3] = a->d[7];
     bin[4] = a->d[6] >> 24; bin[5] = a->d[6] >> 16; bin[6] = a->d[6] >> 8; bin[7] = a->d[6];
     bin[8] = a->d[5] >> 24; bin[9] = a->d[5] >> 16; bin[10] = a->d[5] >> 8; bin[11] = a->d[5];
@@ -189,11 +189,11 @@ static void secp256k1_scalar_get_b32(unsigned char *bin, const secp256k1_scalar_
     bin[28] = a->d[0] >> 24; bin[29] = a->d[0] >> 16; bin[30] = a->d[0] >> 8; bin[31] = a->d[0];
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar_t *a) {
+SECP256K1_INLINE static int secp256k1_scalar_is_zero(const secp256k1_scalar *a) {
     return (a->d[0] | a->d[1] | a->d[2] | a->d[3] | a->d[4] | a->d[5] | a->d[6] | a->d[7]) == 0;
 }
 
-static void secp256k1_scalar_negate(secp256k1_scalar_t *r, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_negate(secp256k1_scalar *r, const secp256k1_scalar *a) {
     uint32_t nonzero = 0xFFFFFFFFUL * (secp256k1_scalar_is_zero(a) == 0);
     uint64_t t = (uint64_t)(~a->d[0]) + SECP256K1_N_0 + 1;
     r->d[0] = t & nonzero; t >>= 32;
@@ -213,11 +213,11 @@ static void secp256k1_scalar_negate(secp256k1_scalar_t *r, const secp256k1_scala
     r->d[7] = t & nonzero;
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar_t *a) {
+SECP256K1_INLINE static int secp256k1_scalar_is_one(const secp256k1_scalar *a) {
     return ((a->d[0] ^ 1) | a->d[1] | a->d[2] | a->d[3] | a->d[4] | a->d[5] | a->d[6] | a->d[7]) == 0;
 }
 
-static int secp256k1_scalar_is_high(const secp256k1_scalar_t *a) {
+static int secp256k1_scalar_is_high(const secp256k1_scalar *a) {
     int yes = 0;
     int no = 0;
     no |= (a->d[7] < SECP256K1_N_H_7);
@@ -235,7 +235,7 @@ static int secp256k1_scalar_is_high(const secp256k1_scalar_t *a) {
     return yes;
 }
 
-static int secp256k1_scalar_cond_negate(secp256k1_scalar_t *r, int flag) {
+static int secp256k1_scalar_cond_negate(secp256k1_scalar *r, int flag) {
     /* If we are flag = 0, mask = 00...00 and this is a no-op;
      * if we are flag = 1, mask = 11...11 and this is identical to secp256k1_scalar_negate */
     uint32_t mask = !flag - 1;
@@ -346,7 +346,7 @@ static int secp256k1_scalar_cond_negate(secp256k1_scalar_t *r, int flag) {
     VERIFY_CHECK(c2 == 0); \
 }
 
-static void secp256k1_scalar_reduce_512(secp256k1_scalar_t *r, const uint32_t *l) {
+static void secp256k1_scalar_reduce_512(secp256k1_scalar *r, const uint32_t *l) {
     uint64_t c;
     uint32_t n0 = l[8], n1 = l[9], n2 = l[10], n3 = l[11], n4 = l[12], n5 = l[13], n6 = l[14], n7 = l[15];
     uint32_t m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12;
@@ -488,7 +488,7 @@ static void secp256k1_scalar_reduce_512(secp256k1_scalar_t *r, const uint32_t *l
     secp256k1_scalar_reduce(r, c + secp256k1_scalar_check_overflow(r));
 }
 
-static void secp256k1_scalar_mul_512(uint32_t *l, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+static void secp256k1_scalar_mul_512(uint32_t *l, const secp256k1_scalar *a, const secp256k1_scalar *b) {
     /* 96 bit accumulator. */
     uint32_t c0 = 0, c1 = 0, c2 = 0;
 
@@ -576,7 +576,7 @@ static void secp256k1_scalar_mul_512(uint32_t *l, const secp256k1_scalar_t *a, c
     l[15] = c0;
 }
 
-static void secp256k1_scalar_sqr_512(uint32_t *l, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_sqr_512(uint32_t *l, const secp256k1_scalar *a) {
     /* 96 bit accumulator. */
     uint32_t c0 = 0, c1 = 0, c2 = 0;
 
@@ -644,13 +644,13 @@ static void secp256k1_scalar_sqr_512(uint32_t *l, const secp256k1_scalar_t *a) {
 #undef extract
 #undef extract_fast
 
-static void secp256k1_scalar_mul(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+static void secp256k1_scalar_mul(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b) {
     uint32_t l[16];
     secp256k1_scalar_mul_512(l, a, b);
     secp256k1_scalar_reduce_512(r, l);
 }
 
-static int secp256k1_scalar_shr_int(secp256k1_scalar_t *r, int n) {
+static int secp256k1_scalar_shr_int(secp256k1_scalar *r, int n) {
     int ret;
     VERIFY_CHECK(n > 0);
     VERIFY_CHECK(n < 16);
@@ -666,14 +666,14 @@ static int secp256k1_scalar_shr_int(secp256k1_scalar_t *r, int n) {
     return ret;
 }
 
-static void secp256k1_scalar_sqr(secp256k1_scalar_t *r, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_sqr(secp256k1_scalar *r, const secp256k1_scalar *a) {
     uint32_t l[16];
     secp256k1_scalar_sqr_512(l, a);
     secp256k1_scalar_reduce_512(r, l);
 }
 
 #ifdef USE_ENDOMORPHISM
-static void secp256k1_scalar_split_128(secp256k1_scalar_t *r1, secp256k1_scalar_t *r2, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_split_128(secp256k1_scalar *r1, secp256k1_scalar *r2, const secp256k1_scalar *a) {
     r1->d[0] = a->d[0];
     r1->d[1] = a->d[1];
     r1->d[2] = a->d[2];
@@ -693,11 +693,11 @@ static void secp256k1_scalar_split_128(secp256k1_scalar_t *r1, secp256k1_scalar_
 }
 #endif
 
-SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar_t *a, const secp256k1_scalar_t *b) {
+SECP256K1_INLINE static int secp256k1_scalar_eq(const secp256k1_scalar *a, const secp256k1_scalar *b) {
     return ((a->d[0] ^ b->d[0]) | (a->d[1] ^ b->d[1]) | (a->d[2] ^ b->d[2]) | (a->d[3] ^ b->d[3]) | (a->d[4] ^ b->d[4]) | (a->d[5] ^ b->d[5]) | (a->d[6] ^ b->d[6]) | (a->d[7] ^ b->d[7])) == 0;
 }
 
-SECP256K1_INLINE static void secp256k1_scalar_mul_shift_var(secp256k1_scalar_t *r, const secp256k1_scalar_t *a, const secp256k1_scalar_t *b, unsigned int shift) {
+SECP256K1_INLINE static void secp256k1_scalar_mul_shift_var(secp256k1_scalar *r, const secp256k1_scalar *a, const secp256k1_scalar *b, unsigned int shift) {
     uint32_t l[16];
     unsigned int shiftlimbs;
     unsigned int shiftlow;

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -25,14 +25,14 @@
 #endif
 
 #ifndef USE_NUM_NONE
-static void secp256k1_scalar_get_num(secp256k1_num_t *r, const secp256k1_scalar_t *a) {
+static void secp256k1_scalar_get_num(secp256k1_num *r, const secp256k1_scalar *a) {
     unsigned char c[32];
     secp256k1_scalar_get_b32(c, a);
     secp256k1_num_set_bin(r, c, 32);
 }
 
 /** secp256k1 curve order, see secp256k1_ecdsa_const_order_as_fe in ecdsa_impl.h */
-static void secp256k1_scalar_order_get_num(secp256k1_num_t *r) {
+static void secp256k1_scalar_order_get_num(secp256k1_num *r) {
     static const unsigned char order[32] = {
         0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,
         0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFE,
@@ -43,11 +43,11 @@ static void secp256k1_scalar_order_get_num(secp256k1_num_t *r) {
 }
 #endif
 
-static void secp256k1_scalar_inverse(secp256k1_scalar_t *r, const secp256k1_scalar_t *x) {
-    secp256k1_scalar_t *t;
+static void secp256k1_scalar_inverse(secp256k1_scalar *r, const secp256k1_scalar *x) {
+    secp256k1_scalar *t;
     int i;
     /* First compute x ^ (2^N - 1) for some values of N. */
-    secp256k1_scalar_t x2, x3, x4, x6, x7, x8, x15, x30, x60, x120, x127;
+    secp256k1_scalar x2, x3, x4, x6, x7, x8, x15, x30, x60, x120, x127;
 
     secp256k1_scalar_sqr(&x2,  x);
     secp256k1_scalar_mul(&x2, &x2,  x);
@@ -234,18 +234,18 @@ static void secp256k1_scalar_inverse(secp256k1_scalar_t *r, const secp256k1_scal
     secp256k1_scalar_mul(r, t, &x6); /* 111111 */
 }
 
-SECP256K1_INLINE static int secp256k1_scalar_is_even(const secp256k1_scalar_t *a) {
+SECP256K1_INLINE static int secp256k1_scalar_is_even(const secp256k1_scalar *a) {
     /* d[0] is present and is the lowest word for all representations */
     return !(a->d[0] & 1);
 }
 
-static void secp256k1_scalar_inverse_var(secp256k1_scalar_t *r, const secp256k1_scalar_t *x) {
+static void secp256k1_scalar_inverse_var(secp256k1_scalar *r, const secp256k1_scalar *x) {
 #if defined(USE_SCALAR_INV_BUILTIN)
     secp256k1_scalar_inverse(r, x);
 #elif defined(USE_SCALAR_INV_NUM)
     unsigned char b[32];
-    secp256k1_num_t n, m;
-    secp256k1_scalar_t t = *x;
+    secp256k1_num n, m;
+    secp256k1_scalar t = *x;
     secp256k1_scalar_get_b32(b, &t);
     secp256k1_num_set_bin(&n, b, 32);
     secp256k1_scalar_order_get_num(&m);
@@ -299,25 +299,25 @@ static void secp256k1_scalar_inverse_var(secp256k1_scalar_t *r, const secp256k1_
  * The function below splits a in r1 and r2, such that r1 + lambda * r2 == a (mod order).
  */
 
-static void secp256k1_scalar_split_lambda(secp256k1_scalar_t *r1, secp256k1_scalar_t *r2, const secp256k1_scalar_t *a) {
-    secp256k1_scalar_t c1, c2;
-    static const secp256k1_scalar_t minus_lambda = SECP256K1_SCALAR_CONST(
+static void secp256k1_scalar_split_lambda(secp256k1_scalar *r1, secp256k1_scalar *r2, const secp256k1_scalar *a) {
+    secp256k1_scalar c1, c2;
+    static const secp256k1_scalar minus_lambda = SECP256K1_SCALAR_CONST(
         0xAC9C52B3UL, 0x3FA3CF1FUL, 0x5AD9E3FDUL, 0x77ED9BA4UL,
         0xA880B9FCUL, 0x8EC739C2UL, 0xE0CFC810UL, 0xB51283CFUL
     );
-    static const secp256k1_scalar_t minus_b1 = SECP256K1_SCALAR_CONST(
+    static const secp256k1_scalar minus_b1 = SECP256K1_SCALAR_CONST(
         0x00000000UL, 0x00000000UL, 0x00000000UL, 0x00000000UL,
         0xE4437ED6UL, 0x010E8828UL, 0x6F547FA9UL, 0x0ABFE4C3UL
     );
-    static const secp256k1_scalar_t minus_b2 = SECP256K1_SCALAR_CONST(
+    static const secp256k1_scalar minus_b2 = SECP256K1_SCALAR_CONST(
         0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFFUL, 0xFFFFFFFEUL,
         0x8A280AC5UL, 0x0774346DUL, 0xD765CDA8UL, 0x3DB1562CUL
     );
-    static const secp256k1_scalar_t g1 = SECP256K1_SCALAR_CONST(
+    static const secp256k1_scalar g1 = SECP256K1_SCALAR_CONST(
         0x00000000UL, 0x00000000UL, 0x00000000UL, 0x00003086UL,
         0xD221A7D4UL, 0x6BCDE86CUL, 0x90E49284UL, 0xEB153DABUL
     );
-    static const secp256k1_scalar_t g2 = SECP256K1_SCALAR_CONST(
+    static const secp256k1_scalar g2 = SECP256K1_SCALAR_CONST(
         0x00000000UL, 0x00000000UL, 0x00000000UL, 0x0000E443UL,
         0x7ED6010EUL, 0x88286F54UL, 0x7FA90ABFUL, 0xE4C42212UL
     );

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -22,7 +22,7 @@
 
 #define ARG_CHECK(cond) do { \
     if (EXPECT(!(cond), 0)) { \
-        secp256k1_callback(&ctx->illegal_callback, #cond); \
+        secp256k1_callback_call(&ctx->illegal_callback, #cond); \
         return 0; \
     } \
 } while(0)
@@ -33,7 +33,7 @@ static void default_illegal_callback_fn(const char* str, void* data) {
     abort();
 }
 
-static const callback_t default_illegal_callback = {
+static const secp256k1_callback default_illegal_callback = {
     default_illegal_callback_fn,
     NULL
 };
@@ -44,21 +44,21 @@ static void default_error_callback_fn(const char* str, void* data) {
     abort();
 }
 
-static const callback_t default_error_callback = {
+static const secp256k1_callback default_error_callback = {
     default_error_callback_fn,
     NULL
 };
 
 
 struct secp256k1_context_struct {
-    secp256k1_ecmult_context_t ecmult_ctx;
-    secp256k1_ecmult_gen_context_t ecmult_gen_ctx;
-    callback_t illegal_callback;
-    callback_t error_callback;
+    secp256k1_ecmult_context ecmult_ctx;
+    secp256k1_ecmult_gen_context ecmult_gen_ctx;
+    secp256k1_callback illegal_callback;
+    secp256k1_callback error_callback;
 };
 
-secp256k1_context_t* secp256k1_context_create(unsigned int flags) {
-    secp256k1_context_t* ret = (secp256k1_context_t*)checked_malloc(&default_error_callback, sizeof(secp256k1_context_t));
+secp256k1_context* secp256k1_context_create(unsigned int flags) {
+    secp256k1_context* ret = (secp256k1_context*)checked_malloc(&default_error_callback, sizeof(secp256k1_context));
     ret->illegal_callback = default_illegal_callback;
     ret->error_callback = default_error_callback;
 
@@ -75,8 +75,8 @@ secp256k1_context_t* secp256k1_context_create(unsigned int flags) {
     return ret;
 }
 
-secp256k1_context_t* secp256k1_context_clone(const secp256k1_context_t* ctx) {
-    secp256k1_context_t* ret = (secp256k1_context_t*)checked_malloc(&ctx->error_callback, sizeof(secp256k1_context_t));
+secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
+    secp256k1_context* ret = (secp256k1_context*)checked_malloc(&ctx->error_callback, sizeof(secp256k1_context));
     ret->illegal_callback = ctx->illegal_callback;
     ret->error_callback = ctx->error_callback;
     secp256k1_ecmult_context_clone(&ret->ecmult_ctx, &ctx->ecmult_ctx, &ctx->error_callback);
@@ -84,7 +84,7 @@ secp256k1_context_t* secp256k1_context_clone(const secp256k1_context_t* ctx) {
     return ret;
 }
 
-void secp256k1_context_destroy(secp256k1_context_t* ctx) {
+void secp256k1_context_destroy(secp256k1_context* ctx) {
     if (ctx) {
         secp256k1_ecmult_context_clear(&ctx->ecmult_ctx);
         secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);
@@ -93,7 +93,7 @@ void secp256k1_context_destroy(secp256k1_context_t* ctx) {
     }
 }
 
-void secp256k1_context_set_illegal_callback(secp256k1_context_t* ctx, void (*fun)(const char* message, void* data), const void* data) {
+void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
     if (!fun) {
         fun = default_illegal_callback_fn;
     }
@@ -101,7 +101,7 @@ void secp256k1_context_set_illegal_callback(secp256k1_context_t* ctx, void (*fun
     ctx->illegal_callback.data = data;
 }
 
-void secp256k1_context_set_error_callback(secp256k1_context_t* ctx, void (*fun)(const char* message, void* data), const void* data) {
+void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
     if (!fun) {
         fun = default_error_callback_fn;
     }
@@ -109,17 +109,17 @@ void secp256k1_context_set_error_callback(secp256k1_context_t* ctx, void (*fun)(
     ctx->error_callback.data = data;
 }
 
-static int secp256k1_pubkey_load(const secp256k1_context_t* ctx, secp256k1_ge_t* ge, const secp256k1_pubkey_t* pubkey) {
-    if (sizeof(secp256k1_ge_storage_t) == 64) {
-        /* When the secp256k1_ge_storage_t type is exactly 64 byte, use its
-         * representation inside secp256k1_pubkey_t, as conversion is very fast.
+static int secp256k1_pubkey_load(const secp256k1_context* ctx, secp256k1_ge* ge, const secp256k1_pubkey* pubkey) {
+    if (sizeof(secp256k1_ge_storage) == 64) {
+        /* When the secp256k1_ge_storage type is exactly 64 byte, use its
+         * representation inside secp256k1_pubkey, as conversion is very fast.
          * Note that secp256k1_pubkey_save must use the same representation. */
-        secp256k1_ge_storage_t s;
+        secp256k1_ge_storage s;
         memcpy(&s, &pubkey->data[0], 64);
         secp256k1_ge_from_storage(ge, &s);
     } else {
         /* Otherwise, fall back to 32-byte big endian for X and Y. */
-        secp256k1_fe_t x, y;
+        secp256k1_fe x, y;
         secp256k1_fe_set_b32(&x, pubkey->data);
         secp256k1_fe_set_b32(&y, pubkey->data + 32);
         secp256k1_ge_set_xy(ge, &x, &y);
@@ -128,9 +128,9 @@ static int secp256k1_pubkey_load(const secp256k1_context_t* ctx, secp256k1_ge_t*
     return 1;
 }
 
-static void secp256k1_pubkey_save(secp256k1_pubkey_t* pubkey, secp256k1_ge_t* ge) {
-    if (sizeof(secp256k1_ge_storage_t) == 64) {
-        secp256k1_ge_storage_t s;
+static void secp256k1_pubkey_save(secp256k1_pubkey* pubkey, secp256k1_ge* ge) {
+    if (sizeof(secp256k1_ge_storage) == 64) {
+        secp256k1_ge_storage s;
         secp256k1_ge_to_storage(&s, ge);
         memcpy(&pubkey->data[0], &s, 64);
     } else {
@@ -142,8 +142,8 @@ static void secp256k1_pubkey_save(secp256k1_pubkey_t* pubkey, secp256k1_ge_t* ge
     }
 }
 
-int secp256k1_ec_pubkey_parse(const secp256k1_context_t* ctx, secp256k1_pubkey_t* pubkey, const unsigned char *input, size_t inputlen) {
-    secp256k1_ge_t Q;
+int secp256k1_ec_pubkey_parse(const secp256k1_context* ctx, secp256k1_pubkey* pubkey, const unsigned char *input, size_t inputlen) {
+    secp256k1_ge Q;
 
     (void)ctx;
     if (!secp256k1_eckey_pubkey_parse(&Q, input, inputlen)) {
@@ -155,19 +155,19 @@ int secp256k1_ec_pubkey_parse(const secp256k1_context_t* ctx, secp256k1_pubkey_t
     return 1;
 }
 
-int secp256k1_ec_pubkey_serialize(const secp256k1_context_t* ctx, unsigned char *output, size_t *outputlen, const secp256k1_pubkey_t* pubkey, unsigned int flags) {
-    secp256k1_ge_t Q;
+int secp256k1_ec_pubkey_serialize(const secp256k1_context* ctx, unsigned char *output, size_t *outputlen, const secp256k1_pubkey* pubkey, unsigned int flags) {
+    secp256k1_ge Q;
 
     (void)ctx;
     return (secp256k1_pubkey_load(ctx, &Q, pubkey) &&
             secp256k1_eckey_pubkey_serialize(&Q, output, outputlen, flags));
 }
 
-static void secp256k1_ecdsa_signature_load(const secp256k1_context_t* ctx, secp256k1_scalar_t* r, secp256k1_scalar_t* s, const secp256k1_ecdsa_signature_t* sig) {
+static void secp256k1_ecdsa_signature_load(const secp256k1_context* ctx, secp256k1_scalar* r, secp256k1_scalar* s, const secp256k1_ecdsa_signature* sig) {
     (void)ctx;
-    if (sizeof(secp256k1_scalar_t) == 32) {
-        /* When the secp256k1_scalar_t type is exactly 32 byte, use its
-         * representation inside secp256k1_ecdsa_signature_t, as conversion is very fast.
+    if (sizeof(secp256k1_scalar) == 32) {
+        /* When the secp256k1_scalar type is exactly 32 byte, use its
+         * representation inside secp256k1_ecdsa_signature, as conversion is very fast.
          * Note that secp256k1_ecdsa_signature_save must use the same representation. */
         memcpy(r, &sig->data[0], 32);
         memcpy(s, &sig->data[32], 32);
@@ -177,8 +177,8 @@ static void secp256k1_ecdsa_signature_load(const secp256k1_context_t* ctx, secp2
     }
 }
 
-static void secp256k1_ecdsa_signature_save(secp256k1_ecdsa_signature_t* sig, const secp256k1_scalar_t* r, const secp256k1_scalar_t* s) {
-    if (sizeof(secp256k1_scalar_t) == 32) {
+static void secp256k1_ecdsa_signature_save(secp256k1_ecdsa_signature* sig, const secp256k1_scalar* r, const secp256k1_scalar* s) {
+    if (sizeof(secp256k1_scalar) == 32) {
         memcpy(&sig->data[0], r, 32);
         memcpy(&sig->data[32], s, 32);
     } else {
@@ -187,8 +187,8 @@ static void secp256k1_ecdsa_signature_save(secp256k1_ecdsa_signature_t* sig, con
     }
 }
 
-int secp256k1_ecdsa_signature_parse_der(const secp256k1_context_t* ctx, secp256k1_ecdsa_signature_t* sig, const unsigned char *input, size_t inputlen) {
-    secp256k1_scalar_t r, s;
+int secp256k1_ecdsa_signature_parse_der(const secp256k1_context* ctx, secp256k1_ecdsa_signature* sig, const unsigned char *input, size_t inputlen) {
+    secp256k1_scalar r, s;
 
     (void)ctx;
     ARG_CHECK(sig != NULL);
@@ -203,8 +203,8 @@ int secp256k1_ecdsa_signature_parse_der(const secp256k1_context_t* ctx, secp256k
     }
 }
 
-int secp256k1_ecdsa_signature_serialize_der(const secp256k1_context_t* ctx, unsigned char *output, size_t *outputlen, const secp256k1_ecdsa_signature_t* sig) {
-    secp256k1_scalar_t r, s;
+int secp256k1_ecdsa_signature_serialize_der(const secp256k1_context* ctx, unsigned char *output, size_t *outputlen, const secp256k1_ecdsa_signature* sig) {
+    secp256k1_scalar r, s;
 
     (void)ctx;
     ARG_CHECK(output != NULL);
@@ -215,10 +215,10 @@ int secp256k1_ecdsa_signature_serialize_der(const secp256k1_context_t* ctx, unsi
     return secp256k1_ecdsa_sig_serialize(output, outputlen, &r, &s);
 }
 
-int secp256k1_ecdsa_verify(const secp256k1_context_t* ctx, const secp256k1_ecdsa_signature_t *sig, const unsigned char *msg32, const secp256k1_pubkey_t *pubkey) {
-    secp256k1_ge_t q;
-    secp256k1_scalar_t r, s;
-    secp256k1_scalar_t m;
+int secp256k1_ecdsa_verify(const secp256k1_context* ctx, const secp256k1_ecdsa_signature *sig, const unsigned char *msg32, const secp256k1_pubkey *pubkey) {
+    secp256k1_ge q;
+    secp256k1_scalar r, s;
+    secp256k1_scalar m;
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
     ARG_CHECK(msg32 != NULL);
@@ -262,12 +262,12 @@ static int nonce_function_rfc6979(unsigned char *nonce32, const unsigned char *m
    return 1;
 }
 
-const secp256k1_nonce_function_t secp256k1_nonce_function_rfc6979 = nonce_function_rfc6979;
-const secp256k1_nonce_function_t secp256k1_nonce_function_default = nonce_function_rfc6979;
+const secp256k1_nonce_function secp256k1_nonce_function_rfc6979 = nonce_function_rfc6979;
+const secp256k1_nonce_function secp256k1_nonce_function_default = nonce_function_rfc6979;
 
-int secp256k1_ecdsa_sign(const secp256k1_context_t* ctx, secp256k1_ecdsa_signature_t *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function_t noncefp, const void* noncedata) {
-    secp256k1_scalar_t r, s;
-    secp256k1_scalar_t sec, non, msg;
+int secp256k1_ecdsa_sign(const secp256k1_context* ctx, secp256k1_ecdsa_signature *signature, const unsigned char *msg32, const unsigned char *seckey, secp256k1_nonce_function noncefp, const void* noncedata) {
+    secp256k1_scalar r, s;
+    secp256k1_scalar sec, non, msg;
     int ret = 0;
     int overflow = 0;
     unsigned int count = 0;
@@ -311,8 +311,8 @@ int secp256k1_ecdsa_sign(const secp256k1_context_t* ctx, secp256k1_ecdsa_signatu
     return ret;
 }
 
-int secp256k1_ec_seckey_verify(const secp256k1_context_t* ctx, const unsigned char *seckey) {
-    secp256k1_scalar_t sec;
+int secp256k1_ec_seckey_verify(const secp256k1_context* ctx, const unsigned char *seckey) {
+    secp256k1_scalar sec;
     int ret;
     int overflow;
     VERIFY_CHECK(ctx != NULL);
@@ -325,10 +325,10 @@ int secp256k1_ec_seckey_verify(const secp256k1_context_t* ctx, const unsigned ch
     return ret;
 }
 
-int secp256k1_ec_pubkey_create(const secp256k1_context_t* ctx, secp256k1_pubkey_t *pubkey, const unsigned char *seckey) {
-    secp256k1_gej_t pj;
-    secp256k1_ge_t p;
-    secp256k1_scalar_t sec;
+int secp256k1_ec_pubkey_create(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *seckey) {
+    secp256k1_gej pj;
+    secp256k1_ge p;
+    secp256k1_scalar sec;
     int overflow;
     int ret = 0;
     VERIFY_CHECK(ctx != NULL);
@@ -348,9 +348,9 @@ int secp256k1_ec_pubkey_create(const secp256k1_context_t* ctx, secp256k1_pubkey_
     return ret;
 }
 
-int secp256k1_ec_privkey_tweak_add(const secp256k1_context_t* ctx, unsigned char *seckey, const unsigned char *tweak) {
-    secp256k1_scalar_t term;
-    secp256k1_scalar_t sec;
+int secp256k1_ec_privkey_tweak_add(const secp256k1_context* ctx, unsigned char *seckey, const unsigned char *tweak) {
+    secp256k1_scalar term;
+    secp256k1_scalar sec;
     int ret = 0;
     int overflow = 0;
     VERIFY_CHECK(ctx != NULL);
@@ -371,9 +371,9 @@ int secp256k1_ec_privkey_tweak_add(const secp256k1_context_t* ctx, unsigned char
     return ret;
 }
 
-int secp256k1_ec_pubkey_tweak_add(const secp256k1_context_t* ctx, secp256k1_pubkey_t *pubkey, const unsigned char *tweak) {
-    secp256k1_ge_t p;
-    secp256k1_scalar_t term;
+int secp256k1_ec_pubkey_tweak_add(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *tweak) {
+    secp256k1_ge p;
+    secp256k1_scalar term;
     int ret = 0;
     int overflow = 0;
     VERIFY_CHECK(ctx != NULL);
@@ -394,9 +394,9 @@ int secp256k1_ec_pubkey_tweak_add(const secp256k1_context_t* ctx, secp256k1_pubk
     return ret;
 }
 
-int secp256k1_ec_privkey_tweak_mul(const secp256k1_context_t* ctx, unsigned char *seckey, const unsigned char *tweak) {
-    secp256k1_scalar_t factor;
-    secp256k1_scalar_t sec;
+int secp256k1_ec_privkey_tweak_mul(const secp256k1_context* ctx, unsigned char *seckey, const unsigned char *tweak) {
+    secp256k1_scalar factor;
+    secp256k1_scalar sec;
     int ret = 0;
     int overflow = 0;
     VERIFY_CHECK(ctx != NULL);
@@ -416,9 +416,9 @@ int secp256k1_ec_privkey_tweak_mul(const secp256k1_context_t* ctx, unsigned char
     return ret;
 }
 
-int secp256k1_ec_pubkey_tweak_mul(const secp256k1_context_t* ctx, secp256k1_pubkey_t *pubkey, const unsigned char *tweak) {
-    secp256k1_ge_t p;
-    secp256k1_scalar_t factor;
+int secp256k1_ec_pubkey_tweak_mul(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const unsigned char *tweak) {
+    secp256k1_ge p;
+    secp256k1_scalar factor;
     int ret = 0;
     int overflow = 0;
     VERIFY_CHECK(ctx != NULL);
@@ -439,8 +439,8 @@ int secp256k1_ec_pubkey_tweak_mul(const secp256k1_context_t* ctx, secp256k1_pubk
     return ret;
 }
 
-int secp256k1_ec_privkey_export(const secp256k1_context_t* ctx, unsigned char *privkey, size_t *privkeylen, const unsigned char *seckey, unsigned int flags) {
-    secp256k1_scalar_t key;
+int secp256k1_ec_privkey_export(const secp256k1_context* ctx, unsigned char *privkey, size_t *privkeylen, const unsigned char *seckey, unsigned int flags) {
+    secp256k1_scalar key;
     int ret = 0;
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(seckey != NULL);
@@ -454,8 +454,8 @@ int secp256k1_ec_privkey_export(const secp256k1_context_t* ctx, unsigned char *p
     return ret;
 }
 
-int secp256k1_ec_privkey_import(const secp256k1_context_t* ctx, unsigned char *seckey, const unsigned char *privkey, size_t privkeylen) {
-    secp256k1_scalar_t key;
+int secp256k1_ec_privkey_import(const secp256k1_context* ctx, unsigned char *seckey, const unsigned char *privkey, size_t privkeylen) {
+    secp256k1_scalar key;
     int ret = 0;
     ARG_CHECK(seckey != NULL);
     ARG_CHECK(privkey != NULL);
@@ -469,17 +469,17 @@ int secp256k1_ec_privkey_import(const secp256k1_context_t* ctx, unsigned char *s
     return ret;
 }
 
-int secp256k1_context_randomize(secp256k1_context_t* ctx, const unsigned char *seed32) {
+int secp256k1_context_randomize(secp256k1_context* ctx, const unsigned char *seed32) {
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     secp256k1_ecmult_gen_blind(&ctx->ecmult_gen_ctx, seed32);
     return 1;
 }
 
-int secp256k1_ec_pubkey_combine(const secp256k1_context_t* ctx, secp256k1_pubkey_t *pubnonce, const secp256k1_pubkey_t * const *pubnonces, int n) {
+int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, const secp256k1_pubkey * const *pubnonces, int n) {
     int i;
-    secp256k1_gej_t Qj;
-    secp256k1_ge_t Q;
+    secp256k1_gej Qj;
+    secp256k1_ge Q;
 
     ARG_CHECK(pubnonce != NULL);
     ARG_CHECK(n >= 1);

--- a/src/tests.c
+++ b/src/tests.c
@@ -25,9 +25,9 @@
 #endif
 
 static int count = 64;
-static secp256k1_context_t *ctx = NULL;
+static secp256k1_context *ctx = NULL;
 
-void random_field_element_test(secp256k1_fe_t *fe) {
+void random_field_element_test(secp256k1_fe *fe) {
     do {
         unsigned char b32[32];
         secp256k1_rand256_test(b32);
@@ -37,8 +37,8 @@ void random_field_element_test(secp256k1_fe_t *fe) {
     } while(1);
 }
 
-void random_field_element_magnitude(secp256k1_fe_t *fe) {
-    secp256k1_fe_t zero;
+void random_field_element_magnitude(secp256k1_fe *fe) {
+    secp256k1_fe zero;
     int n = secp256k1_rand32() % 9;
     secp256k1_fe_normalize(fe);
     if (n == 0) {
@@ -51,8 +51,8 @@ void random_field_element_magnitude(secp256k1_fe_t *fe) {
     VERIFY_CHECK(fe->magnitude == n);
 }
 
-void random_group_element_test(secp256k1_ge_t *ge) {
-    secp256k1_fe_t fe;
+void random_group_element_test(secp256k1_ge *ge) {
+    secp256k1_fe fe;
     do {
         random_field_element_test(&fe);
         if (secp256k1_ge_set_xo_var(ge, &fe, secp256k1_rand32() & 1)) {
@@ -62,8 +62,8 @@ void random_group_element_test(secp256k1_ge_t *ge) {
     } while(1);
 }
 
-void random_group_element_jacobian_test(secp256k1_gej_t *gej, const secp256k1_ge_t *ge) {
-    secp256k1_fe_t z2, z3;
+void random_group_element_jacobian_test(secp256k1_gej *gej, const secp256k1_ge *ge) {
+    secp256k1_fe z2, z3;
     do {
         random_field_element_test(&gej->z);
         if (!secp256k1_fe_is_zero(&gej->z)) {
@@ -77,7 +77,7 @@ void random_group_element_jacobian_test(secp256k1_gej_t *gej, const secp256k1_ge
     gej->infinity = ge->infinity;
 }
 
-void random_scalar_order_test(secp256k1_scalar_t *num) {
+void random_scalar_order_test(secp256k1_scalar *num) {
     do {
         unsigned char b32[32];
         int overflow = 0;
@@ -90,7 +90,7 @@ void random_scalar_order_test(secp256k1_scalar_t *num) {
     } while(1);
 }
 
-void random_scalar_order(secp256k1_scalar_t *num) {
+void random_scalar_order(secp256k1_scalar *num) {
     do {
         unsigned char b32[32];
         int overflow = 0;
@@ -104,19 +104,19 @@ void random_scalar_order(secp256k1_scalar_t *num) {
 }
 
 void run_context_tests(void) {
-    secp256k1_context_t *none = secp256k1_context_create(0);
-    secp256k1_context_t *sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
-    secp256k1_context_t *vrfy = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-    secp256k1_context_t *both = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    secp256k1_context *none = secp256k1_context_create(0);
+    secp256k1_context *sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+    secp256k1_context *vrfy = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
+    secp256k1_context *both = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
-    secp256k1_gej_t pubj;
-    secp256k1_ge_t pub;
-    secp256k1_scalar_t msg, key, nonce;
-    secp256k1_scalar_t sigr, sigs;
+    secp256k1_gej pubj;
+    secp256k1_ge pub;
+    secp256k1_scalar msg, key, nonce;
+    secp256k1_scalar sigr, sigs;
 
     /*** clone and destroy all of them to make sure cloning was complete ***/
     {
-        secp256k1_context_t *ctx_tmp;
+        secp256k1_context *ctx_tmp;
 
         ctx_tmp = none; none = secp256k1_context_clone(none); secp256k1_context_destroy(ctx_tmp);
         ctx_tmp = sign; sign = secp256k1_context_clone(sign); secp256k1_context_destroy(ctx_tmp);
@@ -276,27 +276,27 @@ void run_rfc6979_hmac_sha256_tests(void) {
 /***** NUM TESTS *****/
 
 #ifndef USE_NUM_NONE
-void random_num_negate(secp256k1_num_t *num) {
+void random_num_negate(secp256k1_num *num) {
     if (secp256k1_rand32() & 1) {
         secp256k1_num_negate(num);
     }
 }
 
-void random_num_order_test(secp256k1_num_t *num) {
-    secp256k1_scalar_t sc;
+void random_num_order_test(secp256k1_num *num) {
+    secp256k1_scalar sc;
     random_scalar_order_test(&sc);
     secp256k1_scalar_get_num(num, &sc);
 }
 
-void random_num_order(secp256k1_num_t *num) {
-    secp256k1_scalar_t sc;
+void random_num_order(secp256k1_num *num) {
+    secp256k1_scalar sc;
     random_scalar_order(&sc);
     secp256k1_scalar_get_num(num, &sc);
 }
 
 void test_num_negate(void) {
-    secp256k1_num_t n1;
-    secp256k1_num_t n2;
+    secp256k1_num n1;
+    secp256k1_num n2;
     random_num_order_test(&n1); /* n1 = R */
     random_num_negate(&n1);
     secp256k1_num_copy(&n2, &n1); /* n2 = R */
@@ -315,9 +315,9 @@ void test_num_negate(void) {
 }
 
 void test_num_add_sub(void) {
-    secp256k1_num_t n1;
-    secp256k1_num_t n2;
-    secp256k1_num_t n1p2, n2p1, n1m2, n2m1;
+    secp256k1_num n1;
+    secp256k1_num n2;
+    secp256k1_num n1p2, n2p1, n1m2, n2m1;
     int r = secp256k1_rand32();
     random_num_order_test(&n1); /* n1 = R1 */
     if (r & 1) {
@@ -355,12 +355,12 @@ void run_num_smalltests(void) {
 /***** SCALAR TESTS *****/
 
 void scalar_test(void) {
-    secp256k1_scalar_t s;
-    secp256k1_scalar_t s1;
-    secp256k1_scalar_t s2;
+    secp256k1_scalar s;
+    secp256k1_scalar s1;
+    secp256k1_scalar s2;
 #ifndef USE_NUM_NONE
-    secp256k1_num_t snum, s1num, s2num;
-    secp256k1_num_t order, half_order;
+    secp256k1_num snum, s1num, s2num;
+    secp256k1_num order, half_order;
 #endif
     unsigned char c[32];
 
@@ -387,10 +387,10 @@ void scalar_test(void) {
     {
         int i;
         /* Test that fetching groups of 4 bits from a scalar and recursing n(i)=16*n(i-1)+p(i) reconstructs it. */
-        secp256k1_scalar_t n;
+        secp256k1_scalar n;
         secp256k1_scalar_set_int(&n, 0);
         for (i = 0; i < 256; i += 4) {
-            secp256k1_scalar_t t;
+            secp256k1_scalar t;
             int j;
             secp256k1_scalar_set_int(&t, secp256k1_scalar_get_bits(&s, 256 - 4 - i, 4));
             for (j = 0; j < 4; j++) {
@@ -403,11 +403,11 @@ void scalar_test(void) {
 
     {
         /* Test that fetching groups of randomly-sized bits from a scalar and recursing n(i)=b*n(i-1)+p(i) reconstructs it. */
-        secp256k1_scalar_t n;
+        secp256k1_scalar n;
         int i = 0;
         secp256k1_scalar_set_int(&n, 0);
         while (i < 256) {
-            secp256k1_scalar_t t;
+            secp256k1_scalar t;
             int j;
             int now = (secp256k1_rand32() % 15) + 1;
             if (now + i > 256) {
@@ -426,9 +426,9 @@ void scalar_test(void) {
 #ifndef USE_NUM_NONE
     {
         /* Test that adding the scalars together is equal to adding their numbers together modulo the order. */
-        secp256k1_num_t rnum;
-        secp256k1_num_t r2num;
-        secp256k1_scalar_t r;
+        secp256k1_num rnum;
+        secp256k1_num r2num;
+        secp256k1_scalar r;
         secp256k1_num_add(&rnum, &snum, &s2num);
         secp256k1_num_mod(&rnum, &order);
         secp256k1_scalar_add(&r, &s, &s2);
@@ -438,9 +438,9 @@ void scalar_test(void) {
 
     {
         /* Test that multipying the scalars is equal to multiplying their numbers modulo the order. */
-        secp256k1_scalar_t r;
-        secp256k1_num_t r2num;
-        secp256k1_num_t rnum;
+        secp256k1_scalar r;
+        secp256k1_num r2num;
+        secp256k1_num rnum;
         secp256k1_num_mul(&rnum, &snum, &s2num);
         secp256k1_num_mod(&rnum, &order);
         secp256k1_scalar_mul(&r, &s, &s2);
@@ -454,9 +454,9 @@ void scalar_test(void) {
     }
 
     {
-        secp256k1_scalar_t neg;
-        secp256k1_num_t negnum;
-        secp256k1_num_t negnum2;
+        secp256k1_scalar neg;
+        secp256k1_num negnum;
+        secp256k1_num negnum2;
         /* Check that comparison with zero matches comparison with zero on the number. */
         CHECK(secp256k1_num_is_zero(&snum) == secp256k1_scalar_is_zero(&s));
         /* Check that comparison with the half order is equal to testing for high scalar. */
@@ -481,10 +481,10 @@ void scalar_test(void) {
 
     {
         /* Test secp256k1_scalar_mul_shift_var. */
-        secp256k1_scalar_t r;
-        secp256k1_num_t one;
-        secp256k1_num_t rnum;
-        secp256k1_num_t rnum2;
+        secp256k1_scalar r;
+        secp256k1_num one;
+        secp256k1_num rnum;
+        secp256k1_num rnum2;
         unsigned char cone[1] = {0x01};
         unsigned int shift = 256 + (secp256k1_rand32() % 257);
         secp256k1_scalar_mul_shift_var(&r, &s1, &s2, shift);
@@ -499,7 +499,7 @@ void scalar_test(void) {
 
     {
         /* test secp256k1_scalar_shr_int */
-        secp256k1_scalar_t r;
+        secp256k1_scalar r;
         int i;
         int low;
         random_scalar_order_test(&r);
@@ -515,10 +515,10 @@ void scalar_test(void) {
     {
         /* Test that scalar inverses are equal to the inverse of their number modulo the order. */
         if (!secp256k1_scalar_is_zero(&s)) {
-            secp256k1_scalar_t inv;
+            secp256k1_scalar inv;
 #ifndef USE_NUM_NONE
-            secp256k1_num_t invnum;
-            secp256k1_num_t invnum2;
+            secp256k1_num invnum;
+            secp256k1_num invnum2;
 #endif
             secp256k1_scalar_inverse(&inv, &s);
 #ifndef USE_NUM_NONE
@@ -537,15 +537,15 @@ void scalar_test(void) {
 
     {
         /* Test commutativity of add. */
-        secp256k1_scalar_t r1, r2;
+        secp256k1_scalar r1, r2;
         secp256k1_scalar_add(&r1, &s1, &s2);
         secp256k1_scalar_add(&r2, &s2, &s1);
         CHECK(secp256k1_scalar_eq(&r1, &r2));
     }
 
     {
-        secp256k1_scalar_t r1, r2;
-        secp256k1_scalar_t b;
+        secp256k1_scalar r1, r2;
+        secp256k1_scalar b;
         int i;
         /* Test add_bit. */
         int bit = secp256k1_rand32() % 256;
@@ -568,7 +568,7 @@ void scalar_test(void) {
 
     {
         /* Test commutativity of mul. */
-        secp256k1_scalar_t r1, r2;
+        secp256k1_scalar r1, r2;
         secp256k1_scalar_mul(&r1, &s1, &s2);
         secp256k1_scalar_mul(&r2, &s2, &s1);
         CHECK(secp256k1_scalar_eq(&r1, &r2));
@@ -576,7 +576,7 @@ void scalar_test(void) {
 
     {
         /* Test associativity of add. */
-        secp256k1_scalar_t r1, r2;
+        secp256k1_scalar r1, r2;
         secp256k1_scalar_add(&r1, &s1, &s2);
         secp256k1_scalar_add(&r1, &r1, &s);
         secp256k1_scalar_add(&r2, &s2, &s);
@@ -586,7 +586,7 @@ void scalar_test(void) {
 
     {
         /* Test associativity of mul. */
-        secp256k1_scalar_t r1, r2;
+        secp256k1_scalar r1, r2;
         secp256k1_scalar_mul(&r1, &s1, &s2);
         secp256k1_scalar_mul(&r1, &r1, &s);
         secp256k1_scalar_mul(&r2, &s2, &s);
@@ -596,7 +596,7 @@ void scalar_test(void) {
 
     {
         /* Test distributitivity of mul over add. */
-        secp256k1_scalar_t r1, r2, t;
+        secp256k1_scalar r1, r2, t;
         secp256k1_scalar_add(&r1, &s1, &s2);
         secp256k1_scalar_mul(&r1, &r1, &s);
         secp256k1_scalar_mul(&r2, &s1, &s);
@@ -607,7 +607,7 @@ void scalar_test(void) {
 
     {
         /* Test square. */
-        secp256k1_scalar_t r1, r2;
+        secp256k1_scalar r1, r2;
         secp256k1_scalar_sqr(&r1, &s1);
         secp256k1_scalar_mul(&r2, &s1, &s1);
         CHECK(secp256k1_scalar_eq(&r1, &r2));
@@ -615,7 +615,7 @@ void scalar_test(void) {
 
     {
         /* Test multiplicative identity. */
-        secp256k1_scalar_t r1, v1;
+        secp256k1_scalar r1, v1;
         secp256k1_scalar_set_int(&v1,1);
         secp256k1_scalar_mul(&r1, &s1, &v1);
         CHECK(secp256k1_scalar_eq(&r1, &s1));
@@ -623,7 +623,7 @@ void scalar_test(void) {
 
     {
         /* Test additive identity. */
-        secp256k1_scalar_t r1, v0;
+        secp256k1_scalar r1, v0;
         secp256k1_scalar_set_int(&v0,0);
         secp256k1_scalar_add(&r1, &s1, &v0);
         CHECK(secp256k1_scalar_eq(&r1, &s1));
@@ -631,7 +631,7 @@ void scalar_test(void) {
 
     {
         /* Test zero product property. */
-        secp256k1_scalar_t r1, v0;
+        secp256k1_scalar r1, v0;
         secp256k1_scalar_set_int(&v0,0);
         secp256k1_scalar_mul(&r1, &s1, &v0);
         CHECK(secp256k1_scalar_eq(&r1, &v0));
@@ -647,7 +647,7 @@ void run_scalar_tests(void) {
 
     {
         /* (-1)+1 should be zero. */
-        secp256k1_scalar_t s, o;
+        secp256k1_scalar s, o;
         secp256k1_scalar_set_int(&s, 1);
         CHECK(secp256k1_scalar_is_one(&s));
         secp256k1_scalar_negate(&o, &s);
@@ -660,8 +660,8 @@ void run_scalar_tests(void) {
 #ifndef USE_NUM_NONE
     {
         /* A scalar with value of the curve order should be 0. */
-        secp256k1_num_t order;
-        secp256k1_scalar_t zero;
+        secp256k1_num order;
+        secp256k1_scalar zero;
         unsigned char bin[32];
         int overflow = 0;
         secp256k1_scalar_order_get_num(&order);
@@ -675,7 +675,7 @@ void run_scalar_tests(void) {
 
 /***** FIELD TESTS *****/
 
-void random_fe(secp256k1_fe_t *x) {
+void random_fe(secp256k1_fe *x) {
     unsigned char bin[32];
     do {
         secp256k1_rand256(bin);
@@ -685,7 +685,7 @@ void random_fe(secp256k1_fe_t *x) {
     } while(1);
 }
 
-void random_fe_non_zero(secp256k1_fe_t *nz) {
+void random_fe_non_zero(secp256k1_fe *nz) {
     int tries = 10;
     while (--tries >= 0) {
         random_fe(nz);
@@ -698,25 +698,25 @@ void random_fe_non_zero(secp256k1_fe_t *nz) {
     CHECK(tries >= 0);
 }
 
-void random_fe_non_square(secp256k1_fe_t *ns) {
-    secp256k1_fe_t r;
+void random_fe_non_square(secp256k1_fe *ns) {
+    secp256k1_fe r;
     random_fe_non_zero(ns);
     if (secp256k1_fe_sqrt_var(&r, ns)) {
         secp256k1_fe_negate(ns, ns, 1);
     }
 }
 
-int check_fe_equal(const secp256k1_fe_t *a, const secp256k1_fe_t *b) {
-    secp256k1_fe_t an = *a;
-    secp256k1_fe_t bn = *b;
+int check_fe_equal(const secp256k1_fe *a, const secp256k1_fe *b) {
+    secp256k1_fe an = *a;
+    secp256k1_fe bn = *b;
     secp256k1_fe_normalize_weak(&an);
     secp256k1_fe_normalize_var(&bn);
     return secp256k1_fe_equal_var(&an, &bn);
 }
 
-int check_fe_inverse(const secp256k1_fe_t *a, const secp256k1_fe_t *ai) {
-    secp256k1_fe_t x;
-    secp256k1_fe_t one = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 1);
+int check_fe_inverse(const secp256k1_fe *a, const secp256k1_fe *ai) {
+    secp256k1_fe x;
+    secp256k1_fe one = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 1);
     secp256k1_fe_mul(&x, a, ai);
     return check_fe_equal(&x, &one);
 }
@@ -728,17 +728,17 @@ void run_field_convert(void) {
         0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29,
         0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x40
     };
-    static const secp256k1_fe_storage_t fes = SECP256K1_FE_STORAGE_CONST(
+    static const secp256k1_fe_storage fes = SECP256K1_FE_STORAGE_CONST(
         0x00010203UL, 0x04050607UL, 0x11121314UL, 0x15161718UL,
         0x22232425UL, 0x26272829UL, 0x33343536UL, 0x37383940UL
     );
-    static const secp256k1_fe_t fe = SECP256K1_FE_CONST(
+    static const secp256k1_fe fe = SECP256K1_FE_CONST(
         0x00010203UL, 0x04050607UL, 0x11121314UL, 0x15161718UL,
         0x22232425UL, 0x26272829UL, 0x33343536UL, 0x37383940UL
     );
-    secp256k1_fe_t fe2;
+    secp256k1_fe fe2;
     unsigned char b322[32];
-    secp256k1_fe_storage_t fes2;
+    secp256k1_fe_storage fes2;
     /* Check conversions to fe. */
     CHECK(secp256k1_fe_set_b32(&fe2, b32));
     CHECK(secp256k1_fe_equal_var(&fe, &fe2));
@@ -751,24 +751,24 @@ void run_field_convert(void) {
     CHECK(memcmp(&fes2, &fes, sizeof(fes)) == 0);
 }
 
-int fe_memcmp(const secp256k1_fe_t *a, const secp256k1_fe_t *b) {
-    secp256k1_fe_t t = *b;
+int fe_memcmp(const secp256k1_fe *a, const secp256k1_fe *b) {
+    secp256k1_fe t = *b;
 #ifdef VERIFY
     t.magnitude = a->magnitude;
     t.normalized = a->normalized;
 #endif
-    return memcmp(a, &t, sizeof(secp256k1_fe_t));
+    return memcmp(a, &t, sizeof(secp256k1_fe));
 }
 
 void run_field_misc(void) {
-    secp256k1_fe_t x;
-    secp256k1_fe_t y;
-    secp256k1_fe_t z;
-    secp256k1_fe_t q;
-    secp256k1_fe_t fe5 = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 5);
+    secp256k1_fe x;
+    secp256k1_fe y;
+    secp256k1_fe z;
+    secp256k1_fe q;
+    secp256k1_fe fe5 = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 5);
     int i, j;
     for (i = 0; i < 5*count; i++) {
-        secp256k1_fe_storage_t xs, ys, zs;
+        secp256k1_fe_storage xs, ys, zs;
         random_fe(&x);
         random_fe_non_zero(&y);
         /* Test the fe equality and comparison operations. */
@@ -833,7 +833,7 @@ void run_field_misc(void) {
 }
 
 void run_field_inv(void) {
-    secp256k1_fe_t x, xi, xii;
+    secp256k1_fe x, xi, xii;
     int i;
     for (i = 0; i < 10*count; i++) {
         random_fe_non_zero(&x);
@@ -845,7 +845,7 @@ void run_field_inv(void) {
 }
 
 void run_field_inv_var(void) {
-    secp256k1_fe_t x, xi, xii;
+    secp256k1_fe x, xi, xii;
     int i;
     for (i = 0; i < 10*count; i++) {
         random_fe_non_zero(&x);
@@ -857,7 +857,7 @@ void run_field_inv_var(void) {
 }
 
 void run_field_inv_all_var(void) {
-    secp256k1_fe_t x[16], xi[16], xii[16];
+    secp256k1_fe x[16], xi[16], xii[16];
     int i;
     /* Check it's safe to call for 0 elements */
     secp256k1_fe_inv_all_var(0, xi, x);
@@ -879,7 +879,7 @@ void run_field_inv_all_var(void) {
 }
 
 void run_sqr(void) {
-    secp256k1_fe_t x, s;
+    secp256k1_fe x, s;
 
     {
         int i;
@@ -894,8 +894,8 @@ void run_sqr(void) {
     }
 }
 
-void test_sqrt(const secp256k1_fe_t *a, const secp256k1_fe_t *k) {
-    secp256k1_fe_t r1, r2;
+void test_sqrt(const secp256k1_fe *a, const secp256k1_fe *k) {
+    secp256k1_fe r1, r2;
     int v = secp256k1_fe_sqrt_var(&r1, a);
     CHECK((v == 0) == (k == NULL));
 
@@ -909,7 +909,7 @@ void test_sqrt(const secp256k1_fe_t *a, const secp256k1_fe_t *k) {
 }
 
 void run_sqrt(void) {
-    secp256k1_fe_t ns, x, s, t;
+    secp256k1_fe ns, x, s, t;
     int i;
 
     /* Check sqrt(0) is 0 */
@@ -944,7 +944,7 @@ void run_sqrt(void) {
 
 /***** GROUP TESTS *****/
 
-void ge_equals_ge(const secp256k1_ge_t *a, const secp256k1_ge_t *b) {
+void ge_equals_ge(const secp256k1_ge *a, const secp256k1_ge *b) {
     CHECK(a->infinity == b->infinity);
     if (a->infinity) {
         return;
@@ -954,9 +954,9 @@ void ge_equals_ge(const secp256k1_ge_t *a, const secp256k1_ge_t *b) {
 }
 
 /* This compares jacobian points including their Z, not just their geometric meaning. */
-int gej_xyz_equals_gej(const secp256k1_gej_t *a, const secp256k1_gej_t *b) {
-    secp256k1_gej_t a2;
-    secp256k1_gej_t b2;
+int gej_xyz_equals_gej(const secp256k1_gej *a, const secp256k1_gej *b) {
+    secp256k1_gej a2;
+    secp256k1_gej b2;
     int ret = 1;
     ret &= a->infinity == b->infinity;
     if (ret && !a->infinity) {
@@ -975,9 +975,9 @@ int gej_xyz_equals_gej(const secp256k1_gej_t *a, const secp256k1_gej_t *b) {
     return ret;
 }
 
-void ge_equals_gej(const secp256k1_ge_t *a, const secp256k1_gej_t *b) {
-    secp256k1_fe_t z2s;
-    secp256k1_fe_t u1, u2, s1, s2;
+void ge_equals_gej(const secp256k1_ge *a, const secp256k1_gej *b) {
+    secp256k1_fe z2s;
+    secp256k1_fe u1, u2, s1, s2;
     CHECK(a->infinity == b->infinity);
     if (a->infinity) {
         return;
@@ -1006,18 +1006,18 @@ void test_ge(void) {
      *
      * When the endomorphism code is compiled in, p5 = lambda*p1 and p6 = lambda^2*p1 are added as well.
      */
-    secp256k1_ge_t *ge = (secp256k1_ge_t *)malloc(sizeof(secp256k1_ge_t) * (1 + 4 * runs));
-    secp256k1_gej_t *gej = (secp256k1_gej_t *)malloc(sizeof(secp256k1_gej_t) * (1 + 4 * runs));
-    secp256k1_fe_t *zinv = (secp256k1_fe_t *)malloc(sizeof(secp256k1_fe_t) * (1 + 4 * runs));
-    secp256k1_fe_t zf;
-    secp256k1_fe_t zfi2, zfi3;
+    secp256k1_ge *ge = (secp256k1_ge *)malloc(sizeof(secp256k1_ge) * (1 + 4 * runs));
+    secp256k1_gej *gej = (secp256k1_gej *)malloc(sizeof(secp256k1_gej) * (1 + 4 * runs));
+    secp256k1_fe *zinv = (secp256k1_fe *)malloc(sizeof(secp256k1_fe) * (1 + 4 * runs));
+    secp256k1_fe zf;
+    secp256k1_fe zfi2, zfi3;
 
     secp256k1_gej_set_infinity(&gej[0]);
     secp256k1_ge_clear(&ge[0]);
     secp256k1_ge_set_gej_var(&ge[0], &gej[0]);
     for (i = 0; i < runs; i++) {
         int j;
-        secp256k1_ge_t g;
+        secp256k1_ge g;
         random_group_element_test(&g);
 #ifdef USE_ENDOMORPHISM
         if (i >= runs - 2) {
@@ -1046,7 +1046,7 @@ void test_ge(void) {
 
     /* Compute z inverses. */
     {
-        secp256k1_fe_t *zs = malloc(sizeof(secp256k1_fe_t) * (1 + 4 * runs));
+        secp256k1_fe *zs = malloc(sizeof(secp256k1_fe) * (1 + 4 * runs));
         for (i = 0; i < 4 * runs + 1; i++) {
             if (i == 0) {
                 /* The point at infinity does not have a meaningful z inverse. Any should do. */
@@ -1074,13 +1074,13 @@ void test_ge(void) {
         int i2;
         for (i2 = 0; i2 < 1 + 4 * runs; i2++) {
             /* Compute reference result using gej + gej (var). */
-            secp256k1_gej_t refj, resj;
-            secp256k1_ge_t ref;
-            secp256k1_fe_t zr;
+            secp256k1_gej refj, resj;
+            secp256k1_ge ref;
+            secp256k1_fe zr;
             secp256k1_gej_add_var(&refj, &gej[i1], &gej[i2], secp256k1_gej_is_infinity(&gej[i1]) ? NULL : &zr);
             /* Check Z ratio. */
             if (!secp256k1_gej_is_infinity(&gej[i1]) && !secp256k1_gej_is_infinity(&refj)) {
-                secp256k1_fe_t zrz; secp256k1_fe_mul(&zrz, &zr, &gej[i1].z);
+                secp256k1_fe zrz; secp256k1_fe_mul(&zrz, &zr, &gej[i1].z);
                 CHECK(secp256k1_fe_equal_var(&zrz, &refj.z));
             }
             secp256k1_ge_set_gej_var(&ref, &refj);
@@ -1089,13 +1089,13 @@ void test_ge(void) {
             secp256k1_gej_add_ge_var(&resj, &gej[i1], &ge[i2], secp256k1_gej_is_infinity(&gej[i1]) ? NULL : &zr);
             ge_equals_gej(&ref, &resj);
             if (!secp256k1_gej_is_infinity(&gej[i1]) && !secp256k1_gej_is_infinity(&resj)) {
-                secp256k1_fe_t zrz; secp256k1_fe_mul(&zrz, &zr, &gej[i1].z);
+                secp256k1_fe zrz; secp256k1_fe_mul(&zrz, &zr, &gej[i1].z);
                 CHECK(secp256k1_fe_equal_var(&zrz, &resj.z));
             }
 
             /* Test gej + ge (var, with additional Z factor). */
             {
-                secp256k1_ge_t ge2_zfi = ge[i2]; /* the second term with x and y rescaled for z = 1/zf */
+                secp256k1_ge ge2_zfi = ge[i2]; /* the second term with x and y rescaled for z = 1/zf */
                 secp256k1_fe_mul(&ge2_zfi.x, &ge2_zfi.x, &zfi2);
                 secp256k1_fe_mul(&ge2_zfi.y, &ge2_zfi.y, &zfi3);
                 random_field_element_magnitude(&ge2_zfi.x);
@@ -1113,7 +1113,7 @@ void test_ge(void) {
 
             /* Test doubling (var). */
             if ((i1 == 0 && i2 == 0) || ((i1 + 3)/4 == (i2 + 3)/4 && ((i1 + 3)%4)/2 == ((i2 + 3)%4)/2)) {
-                secp256k1_fe_t zr2;
+                secp256k1_fe zr2;
                 /* Normal doubling with Z ratio result. */
                 secp256k1_gej_double_var(&resj, &gej[i1], &zr2);
                 ge_equals_gej(&ref, &resj);
@@ -1146,15 +1146,15 @@ void test_ge(void) {
 
     /* Test adding all points together in random order equals infinity. */
     {
-        secp256k1_gej_t sum = SECP256K1_GEJ_CONST_INFINITY;
-        secp256k1_gej_t *gej_shuffled = (secp256k1_gej_t *)malloc((4 * runs + 1) * sizeof(secp256k1_gej_t));
+        secp256k1_gej sum = SECP256K1_GEJ_CONST_INFINITY;
+        secp256k1_gej *gej_shuffled = (secp256k1_gej *)malloc((4 * runs + 1) * sizeof(secp256k1_gej));
         for (i = 0; i < 4 * runs + 1; i++) {
             gej_shuffled[i] = gej[i];
         }
         for (i = 0; i < 4 * runs + 1; i++) {
             int swap = i + secp256k1_rand32() % (4 * runs + 1 - i);
             if (swap != i) {
-                secp256k1_gej_t t = gej_shuffled[i];
+                secp256k1_gej t = gej_shuffled[i];
                 gej_shuffled[i] = gej_shuffled[swap];
                 gej_shuffled[swap] = t;
             }
@@ -1168,9 +1168,9 @@ void test_ge(void) {
 
     /* Test batch gej -> ge conversion with and without known z ratios. */
     {
-        secp256k1_fe_t *zr = (secp256k1_fe_t *)malloc((4 * runs + 1) * sizeof(secp256k1_fe_t));
-        secp256k1_ge_t *ge_set_table = (secp256k1_ge_t *)malloc((4 * runs + 1) * sizeof(secp256k1_ge_t));
-        secp256k1_ge_t *ge_set_all = (secp256k1_ge_t *)malloc((4 * runs + 1) * sizeof(secp256k1_ge_t));
+        secp256k1_fe *zr = (secp256k1_fe *)malloc((4 * runs + 1) * sizeof(secp256k1_fe));
+        secp256k1_ge *ge_set_table = (secp256k1_ge *)malloc((4 * runs + 1) * sizeof(secp256k1_ge));
+        secp256k1_ge *ge_set_all = (secp256k1_ge *)malloc((4 * runs + 1) * sizeof(secp256k1_ge));
         for (i = 0; i < 4 * runs + 1; i++) {
             /* Compute gej[i + 1].z / gez[i].z (with gej[n].z taken to be 1). */
             if (i < 4 * runs) {
@@ -1180,7 +1180,7 @@ void test_ge(void) {
         secp256k1_ge_set_table_gej_var(4 * runs + 1, ge_set_table, gej, zr);
         secp256k1_ge_set_all_gej_var(4 * runs + 1, ge_set_all, gej, &ctx->error_callback);
         for (i = 0; i < 4 * runs + 1; i++) {
-            secp256k1_fe_t s;
+            secp256k1_fe s;
             random_fe_non_zero(&s);
             secp256k1_gej_rescale(&gej[i], &s);
             ge_equals_gej(&ge_set_table[i], &gej[i]);
@@ -1227,27 +1227,27 @@ void test_add_neg_y_diff_x(void) {
      * print "    Q: %x %x" % Q.xy()
      * print "P + Q: %x %x" % (P + Q).xy()
      */
-    secp256k1_gej_t aj = SECP256K1_GEJ_CONST(
+    secp256k1_gej aj = SECP256K1_GEJ_CONST(
         0x8d24cd95, 0x0a355af1, 0x3c543505, 0x44238d30,
         0x0643d79f, 0x05a59614, 0x2f8ec030, 0xd58977cb,
         0x001e337a, 0x38093dcd, 0x6c0f386d, 0x0b1293a8,
         0x4d72c879, 0xd7681924, 0x44e6d2f3, 0x9190117d
     );
-    secp256k1_gej_t bj = SECP256K1_GEJ_CONST(
+    secp256k1_gej bj = SECP256K1_GEJ_CONST(
         0xc7b74206, 0x1f788cd9, 0xabd0937d, 0x164a0d86,
         0x95f6ff75, 0xf19a4ce9, 0xd013bd7b, 0xbf92d2a7,
         0xffe1cc85, 0xc7f6c232, 0x93f0c792, 0xf4ed6c57,
         0xb28d3786, 0x2897e6db, 0xbb192d0b, 0x6e6feab2
     );
-    secp256k1_gej_t sumj = SECP256K1_GEJ_CONST(
+    secp256k1_gej sumj = SECP256K1_GEJ_CONST(
         0x671a63c0, 0x3efdad4c, 0x389a7798, 0x24356027,
         0xb3d69010, 0x278625c3, 0x5c86d390, 0x184a8f7a,
         0x5f6409c2, 0x2ce01f2b, 0x511fd375, 0x25071d08,
         0xda651801, 0x70e95caf, 0x8f0d893c, 0xbed8fbbe
     );
-    secp256k1_ge_t b;
-    secp256k1_gej_t resj;
-    secp256k1_ge_t res;
+    secp256k1_ge b;
+    secp256k1_gej resj;
+    secp256k1_ge res;
     secp256k1_ge_set_gej(&b, &bj);
 
     secp256k1_gej_add_var(&resj, &aj, &bj, NULL);
@@ -1272,16 +1272,16 @@ void run_ge(void) {
 }
 
 void test_ec_combine(void) {
-    secp256k1_scalar_t sum = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
-    secp256k1_pubkey_t data[6];
-    const secp256k1_pubkey_t* d[6];
-    secp256k1_pubkey_t sd;
-    secp256k1_pubkey_t sd2;
-    secp256k1_gej_t Qj;
-    secp256k1_ge_t Q;
+    secp256k1_scalar sum = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
+    secp256k1_pubkey data[6];
+    const secp256k1_pubkey* d[6];
+    secp256k1_pubkey sd;
+    secp256k1_pubkey sd2;
+    secp256k1_gej Qj;
+    secp256k1_ge Q;
     int i;
     for (i = 1; i <= 6; i++) {
-        secp256k1_scalar_t s;
+        secp256k1_scalar s;
         random_scalar_order_test(&s);
         secp256k1_scalar_add(&sum, &sum, &s);
         secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &Qj, &s);
@@ -1307,30 +1307,30 @@ void run_ec_combine(void) {
 
 void run_ecmult_chain(void) {
     /* random starting point A (on the curve) */
-    secp256k1_gej_t a = SECP256K1_GEJ_CONST(
+    secp256k1_gej a = SECP256K1_GEJ_CONST(
         0x8b30bbe9, 0xae2a9906, 0x96b22f67, 0x0709dff3,
         0x727fd8bc, 0x04d3362c, 0x6c7bf458, 0xe2846004,
         0xa357ae91, 0x5c4a6528, 0x1309edf2, 0x0504740f,
         0x0eb33439, 0x90216b4f, 0x81063cb6, 0x5f2f7e0f
     );
     /* two random initial factors xn and gn */
-    secp256k1_scalar_t xn = SECP256K1_SCALAR_CONST(
+    secp256k1_scalar xn = SECP256K1_SCALAR_CONST(
         0x84cc5452, 0xf7fde1ed, 0xb4d38a8c, 0xe9b1b84c,
         0xcef31f14, 0x6e569be9, 0x705d357a, 0x42985407
     );
-    secp256k1_scalar_t gn = SECP256K1_SCALAR_CONST(
+    secp256k1_scalar gn = SECP256K1_SCALAR_CONST(
         0xa1e58d22, 0x553dcd42, 0xb2398062, 0x5d4c57a9,
         0x6e9323d4, 0x2b3152e5, 0xca2c3990, 0xedc7c9de
     );
     /* two small multipliers to be applied to xn and gn in every iteration: */
-    static const secp256k1_scalar_t xf = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0x1337);
-    static const secp256k1_scalar_t gf = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0x7113);
+    static const secp256k1_scalar xf = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0x1337);
+    static const secp256k1_scalar gf = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0x7113);
     /* accumulators with the resulting coefficients to A and G */
-    secp256k1_scalar_t ae = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 1);
-    secp256k1_scalar_t ge = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
+    secp256k1_scalar ae = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 1);
+    secp256k1_scalar ge = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
     /* actual points */
-    secp256k1_gej_t x = a;
-    secp256k1_gej_t x2;
+    secp256k1_gej x = a;
+    secp256k1_gej x2;
     int i;
 
     /* the point being computed */
@@ -1350,7 +1350,7 @@ void run_ecmult_chain(void) {
         /* verify */
         if (i == 19999) {
             /* expected result after 19999 iterations */
-            secp256k1_gej_t rp = SECP256K1_GEJ_CONST(
+            secp256k1_gej rp = SECP256K1_GEJ_CONST(
                 0xD6E96687, 0xF9B10D09, 0x2A6F3543, 0x9D86CEBE,
                 0xA4535D0D, 0x409F5358, 0x6440BD74, 0xB933E830,
                 0xB95CBCA2, 0xC77DA786, 0x539BE8FD, 0x53354D2D,
@@ -1369,14 +1369,14 @@ void run_ecmult_chain(void) {
     CHECK(secp256k1_gej_is_infinity(&x2));
 }
 
-void test_point_times_order(const secp256k1_gej_t *point) {
+void test_point_times_order(const secp256k1_gej *point) {
     /* X * (point + G) + (order-X) * (pointer + G) = 0 */
-    secp256k1_scalar_t x;
-    secp256k1_scalar_t nx;
-    secp256k1_scalar_t zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
-    secp256k1_scalar_t one = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 1);
-    secp256k1_gej_t res1, res2;
-    secp256k1_ge_t res3;
+    secp256k1_scalar x;
+    secp256k1_scalar nx;
+    secp256k1_scalar zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
+    secp256k1_scalar one = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 1);
+    secp256k1_gej res1, res2;
+    secp256k1_ge res3;
     unsigned char pub[65];
     size_t psize = 65;
     random_scalar_order_test(&x);
@@ -1406,15 +1406,15 @@ void test_point_times_order(const secp256k1_gej_t *point) {
 
 void run_point_times_order(void) {
     int i;
-    secp256k1_fe_t x = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 2);
-    static const secp256k1_fe_t xr = SECP256K1_FE_CONST(
+    secp256k1_fe x = SECP256K1_FE_CONST(0, 0, 0, 0, 0, 0, 0, 2);
+    static const secp256k1_fe xr = SECP256K1_FE_CONST(
         0x7603CB59, 0xB0EF6C63, 0xFE608479, 0x2A0C378C,
         0xDB3233A8, 0x0F8A9A09, 0xA877DEAD, 0x31B38C45
     );
     for (i = 0; i < 500; i++) {
-        secp256k1_ge_t p;
+        secp256k1_ge p;
         if (secp256k1_ge_set_xo_var(&p, &x, 1)) {
-            secp256k1_gej_t j;
+            secp256k1_gej j;
             CHECK(secp256k1_ge_is_valid_var(&p));
             secp256k1_gej_set_ge(&j, &p);
             CHECK(secp256k1_gej_is_valid_var(&j));
@@ -1428,25 +1428,25 @@ void run_point_times_order(void) {
 
 void ecmult_const_random_mult(void) {
     /* random starting point A (on the curve) */
-    secp256k1_ge_t a = SECP256K1_GE_CONST(
+    secp256k1_ge a = SECP256K1_GE_CONST(
         0x6d986544, 0x57ff52b8, 0xcf1b8126, 0x5b802a5b,
         0xa97f9263, 0xb1e88044, 0x93351325, 0x91bc450a,
         0x535c59f7, 0x325e5d2b, 0xc391fbe8, 0x3c12787c,
         0x337e4a98, 0xe82a9011, 0x0123ba37, 0xdd769c7d
     );
     /* random initial factor xn */
-    secp256k1_scalar_t xn = SECP256K1_SCALAR_CONST(
+    secp256k1_scalar xn = SECP256K1_SCALAR_CONST(
         0x649d4f77, 0xc4242df7, 0x7f2079c9, 0x14530327,
         0xa31b876a, 0xd2d8ce2a, 0x2236d5c6, 0xd7b2029b
     );
     /* expected xn * A (from sage) */
-    secp256k1_ge_t expected_b = SECP256K1_GE_CONST(
+    secp256k1_ge expected_b = SECP256K1_GE_CONST(
         0x23773684, 0x4d209dc7, 0x098a786f, 0x20d06fcd,
         0x070a38bf, 0xc11ac651, 0x03004319, 0x1e2a8786,
         0xed8c3b8e, 0xc06dd57b, 0xd06ea66e, 0x45492b0f,
         0xb84e4e1b, 0xfb77e21f, 0x96baae2a, 0x63dec956
     );
-    secp256k1_gej_t b;
+    secp256k1_gej b;
     secp256k1_ecmult_const(&b, &a, &xn);
 
     CHECK(secp256k1_ge_is_valid_var(&a));
@@ -1454,12 +1454,12 @@ void ecmult_const_random_mult(void) {
 }
 
 void ecmult_const_commutativity(void) {
-    secp256k1_scalar_t a;
-    secp256k1_scalar_t b;
-    secp256k1_gej_t res1;
-    secp256k1_gej_t res2;
-    secp256k1_ge_t mid1;
-    secp256k1_ge_t mid2;
+    secp256k1_scalar a;
+    secp256k1_scalar b;
+    secp256k1_gej res1;
+    secp256k1_gej res2;
+    secp256k1_ge mid1;
+    secp256k1_ge mid2;
     random_scalar_order_test(&a);
     random_scalar_order_test(&b);
 
@@ -1475,12 +1475,12 @@ void ecmult_const_commutativity(void) {
 }
 
 void ecmult_const_mult_zero_one(void) {
-    secp256k1_scalar_t zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
-    secp256k1_scalar_t one = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 1);
-    secp256k1_scalar_t negone;
-    secp256k1_gej_t res1;
-    secp256k1_ge_t res2;
-    secp256k1_ge_t point;
+    secp256k1_scalar zero = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
+    secp256k1_scalar one = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 1);
+    secp256k1_scalar negone;
+    secp256k1_gej res1;
+    secp256k1_ge res2;
+    secp256k1_ge point;
     secp256k1_scalar_negate(&negone, &one);
 
     random_group_element_test(&point);
@@ -1498,23 +1498,23 @@ void ecmult_const_mult_zero_one(void) {
 
 void ecmult_const_chain_multiply(void) {
     /* Check known result (randomly generated test problem from sage) */
-    const secp256k1_scalar_t scalar = SECP256K1_SCALAR_CONST(
+    const secp256k1_scalar scalar = SECP256K1_SCALAR_CONST(
         0x4968d524, 0x2abf9b7a, 0x466abbcf, 0x34b11b6d,
         0xcd83d307, 0x827bed62, 0x05fad0ce, 0x18fae63b
     );
-    const secp256k1_gej_t expected_point = SECP256K1_GEJ_CONST(
+    const secp256k1_gej expected_point = SECP256K1_GEJ_CONST(
         0x5494c15d, 0x32099706, 0xc2395f94, 0x348745fd,
         0x757ce30e, 0x4e8c90fb, 0xa2bad184, 0xf883c69f,
         0x5d195d20, 0xe191bf7f, 0x1be3e55f, 0x56a80196,
         0x6071ad01, 0xf1462f66, 0xc997fa94, 0xdb858435
     );
-    secp256k1_gej_t point;
-    secp256k1_ge_t res;
+    secp256k1_gej point;
+    secp256k1_ge res;
     int i;
 
     secp256k1_gej_set_ge(&point, &secp256k1_ge_const_g);
     for (i = 0; i < 100; ++i) {
-        secp256k1_ge_t tmp;
+        secp256k1_ge tmp;
         secp256k1_ge_set_gej(&tmp, &point);
         secp256k1_ecmult_const(&point, &tmp, &scalar);
     }
@@ -1529,8 +1529,8 @@ void run_ecmult_const_tests(void) {
     ecmult_const_chain_multiply();
 }
 
-void test_wnaf(const secp256k1_scalar_t *number, int w) {
-    secp256k1_scalar_t x, two, t;
+void test_wnaf(const secp256k1_scalar *number, int w) {
+    secp256k1_scalar x, two, t;
     int wnaf[256];
     int zeroes = -1;
     int i;
@@ -1563,9 +1563,9 @@ void test_wnaf(const secp256k1_scalar_t *number, int w) {
     CHECK(secp256k1_scalar_eq(&x, number)); /* check that wnaf represents number */
 }
 
-void test_constant_wnaf_negate(const secp256k1_scalar_t *number) {
-    secp256k1_scalar_t neg1 = *number;
-    secp256k1_scalar_t neg2 = *number;
+void test_constant_wnaf_negate(const secp256k1_scalar *number) {
+    secp256k1_scalar neg1 = *number;
+    secp256k1_scalar neg2 = *number;
     int sign1 = 1;
     int sign2 = 1;
 
@@ -1578,14 +1578,14 @@ void test_constant_wnaf_negate(const secp256k1_scalar_t *number) {
     CHECK(secp256k1_scalar_eq(&neg1, &neg2));
 }
 
-void test_constant_wnaf(const secp256k1_scalar_t *number, int w) {
-    secp256k1_scalar_t x, shift;
+void test_constant_wnaf(const secp256k1_scalar *number, int w) {
+    secp256k1_scalar x, shift;
     int wnaf[256] = {0};
     int i;
 #ifdef USE_ENDOMORPHISM
     int skew;
 #endif
-    secp256k1_scalar_t num = *number;
+    secp256k1_scalar num = *number;
 
     secp256k1_scalar_set_int(&x, 0);
     secp256k1_scalar_set_int(&shift, 1 << w);
@@ -1600,7 +1600,7 @@ void test_constant_wnaf(const secp256k1_scalar_t *number, int w) {
 #endif
 
     for (i = WNAF_SIZE(w); i >= 0; --i) {
-        secp256k1_scalar_t t;
+        secp256k1_scalar t;
         int v = wnaf[i];
         CHECK(v != 0); /* check nonzero */
         CHECK(v & 1);  /* check parity */
@@ -1625,7 +1625,7 @@ void test_constant_wnaf(const secp256k1_scalar_t *number, int w) {
 
 void run_wnaf(void) {
     int i;
-    secp256k1_scalar_t n = {{0}};
+    secp256k1_scalar n = {{0}};
 
     /* Sanity check: 1 and 2 are the smallest odd and even numbers and should
      *               have easier-to-diagnose failure modes  */
@@ -1644,9 +1644,9 @@ void run_wnaf(void) {
 
 void test_ecmult_constants(void) {
     /* Test ecmult_gen() for [0..36) and [order-36..0). */
-    secp256k1_scalar_t x;
-    secp256k1_gej_t r;
-    secp256k1_ge_t ng;
+    secp256k1_scalar x;
+    secp256k1_gej r;
+    secp256k1_ge ng;
     int i;
     int j;
     secp256k1_ge_neg(&ng, &secp256k1_ge_const_g);
@@ -1681,13 +1681,13 @@ void run_ecmult_constants(void) {
 
 void test_ecmult_gen_blind(void) {
     /* Test ecmult_gen() blinding and confirm that the blinding changes, the affline points match, and the z's don't match. */
-    secp256k1_scalar_t key;
-    secp256k1_scalar_t b;
+    secp256k1_scalar key;
+    secp256k1_scalar b;
     unsigned char seed32[32];
-    secp256k1_gej_t pgej;
-    secp256k1_gej_t pgej2;
-    secp256k1_gej_t i;
-    secp256k1_ge_t pge;
+    secp256k1_gej pgej;
+    secp256k1_gej pgej2;
+    secp256k1_gej i;
+    secp256k1_ge pge;
     random_scalar_order_test(&key);
     secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &pgej, &key);
     secp256k1_rand256(seed32);
@@ -1704,8 +1704,8 @@ void test_ecmult_gen_blind(void) {
 
 void test_ecmult_gen_blind_reset(void) {
     /* Test ecmult_gen() blinding reset and confirm that the blinding is consistent. */
-    secp256k1_scalar_t b;
-    secp256k1_gej_t initial;
+    secp256k1_scalar b;
+    secp256k1_gej initial;
     secp256k1_ecmult_gen_blind(&ctx->ecmult_gen_ctx, 0);
     b = ctx->ecmult_gen_ctx.blind;
     initial = ctx->ecmult_gen_ctx.initial;
@@ -1725,8 +1725,8 @@ void run_ecmult_gen_blind(void) {
 #ifdef USE_ENDOMORPHISM
 /***** ENDOMORPHISH TESTS *****/
 void test_scalar_split(void) {
-    secp256k1_scalar_t full;
-    secp256k1_scalar_t s1, slam;
+    secp256k1_scalar full;
+    secp256k1_scalar s1, slam;
     const unsigned char zero[32] = {0};
     unsigned char tmp[32];
 
@@ -1752,19 +1752,19 @@ void run_endomorphism_tests(void) {
 }
 #endif
 
-void random_sign(secp256k1_scalar_t *sigr, secp256k1_scalar_t *sigs, const secp256k1_scalar_t *key, const secp256k1_scalar_t *msg, int *recid) {
-    secp256k1_scalar_t nonce;
+void random_sign(secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *key, const secp256k1_scalar *msg, int *recid) {
+    secp256k1_scalar nonce;
     do {
         random_scalar_order_test(&nonce);
     } while(!secp256k1_ecdsa_sig_sign(&ctx->ecmult_gen_ctx, sigr, sigs, key, msg, &nonce, recid));
 }
 
 void test_ecdsa_sign_verify(void) {
-    secp256k1_gej_t pubj;
-    secp256k1_ge_t pub;
-    secp256k1_scalar_t one;
-    secp256k1_scalar_t msg, key;
-    secp256k1_scalar_t sigr, sigs;
+    secp256k1_gej pubj;
+    secp256k1_ge pub;
+    secp256k1_scalar one;
+    secp256k1_scalar msg, key;
+    secp256k1_scalar sigr, sigs;
     int recid;
     int getrec;
     random_scalar_order_test(&msg);
@@ -1836,9 +1836,9 @@ static int nonce_function_test_retry(unsigned char *nonce32, const unsigned char
    return nonce_function_rfc6979(nonce32, msg32, key32, algo16, data, counter - 5);
 }
 
-int is_empty_signature(const secp256k1_ecdsa_signature_t *sig) {
-    static const unsigned char res[sizeof(secp256k1_ecdsa_signature_t)] = {0};
-    return memcmp(sig, res, sizeof(secp256k1_ecdsa_signature_t)) == 0;
+int is_empty_signature(const secp256k1_ecdsa_signature *sig) {
+    static const unsigned char res[sizeof(secp256k1_ecdsa_signature)] = {0};
+    return memcmp(sig, res, sizeof(secp256k1_ecdsa_signature)) == 0;
 }
 
 void test_ecdsa_end_to_end(void) {
@@ -1846,18 +1846,18 @@ void test_ecdsa_end_to_end(void) {
     unsigned char privkey[32];
     unsigned char message[32];
     unsigned char privkey2[32];
-    secp256k1_ecdsa_signature_t signature[5];
+    secp256k1_ecdsa_signature signature[5];
     unsigned char sig[74];
     size_t siglen = 74;
     unsigned char pubkeyc[65];
     size_t pubkeyclen = 65;
-    secp256k1_pubkey_t pubkey;
+    secp256k1_pubkey pubkey;
     unsigned char seckey[300];
     size_t seckeylen = 300;
 
     /* Generate a random key and message. */
     {
-        secp256k1_scalar_t msg, key;
+        secp256k1_scalar msg, key;
         random_scalar_order_test(&msg);
         random_scalar_order_test(&key);
         secp256k1_scalar_get_b32(privkey, &key);
@@ -1883,7 +1883,7 @@ void test_ecdsa_end_to_end(void) {
         int ret1;
         int ret2;
         unsigned char rnd[32];
-        secp256k1_pubkey_t pubkey2;
+        secp256k1_pubkey pubkey2;
         secp256k1_rand256_test(rnd);
         ret1 = secp256k1_ec_privkey_tweak_add(ctx, privkey, rnd);
         ret2 = secp256k1_ec_pubkey_tweak_add(ctx, &pubkey, rnd);
@@ -1900,7 +1900,7 @@ void test_ecdsa_end_to_end(void) {
         int ret1;
         int ret2;
         unsigned char rnd[32];
-        secp256k1_pubkey_t pubkey2;
+        secp256k1_pubkey pubkey2;
         secp256k1_rand256_test(rnd);
         ret1 = secp256k1_ec_privkey_tweak_mul(ctx, privkey, rnd);
         ret2 = secp256k1_ec_pubkey_tweak_mul(ctx, &pubkey, rnd);
@@ -1948,8 +1948,8 @@ void test_ecdsa_end_to_end(void) {
 }
 
 void test_random_pubkeys(void) {
-    secp256k1_ge_t elem;
-    secp256k1_ge_t elem2;
+    secp256k1_ge elem;
+    secp256k1_ge elem2;
     unsigned char in[65];
     /* Generate some randomly sized pubkeys. */
     uint32_t r = secp256k1_rand32();
@@ -2029,14 +2029,14 @@ void run_ecdsa_end_to_end(void) {
 /* Tests several edge cases. */
 void test_ecdsa_edge_cases(void) {
     int t;
-    secp256k1_ecdsa_signature_t sig;
+    secp256k1_ecdsa_signature sig;
 
     /* Test the case where ECDSA recomputes a point that is infinity. */
     {
-        secp256k1_gej_t keyj;
-        secp256k1_ge_t key;
-        secp256k1_scalar_t msg;
-        secp256k1_scalar_t sr, ss;
+        secp256k1_gej keyj;
+        secp256k1_ge key;
+        secp256k1_scalar msg;
+        secp256k1_scalar sr, ss;
         secp256k1_scalar_set_int(&ss, 1);
         secp256k1_scalar_negate(&ss, &ss);
         secp256k1_scalar_inverse(&ss, &ss);
@@ -2092,8 +2092,8 @@ void test_ecdsa_edge_cases(void) {
         int i;
         unsigned char key[32];
         unsigned char msg[32];
-        secp256k1_ecdsa_signature_t sig2;
-        secp256k1_scalar_t sr[512], ss;
+        secp256k1_ecdsa_signature sig2;
+        secp256k1_scalar sr[512], ss;
         const unsigned char *extra;
         extra = t == 0 ? NULL : zero;
         memset(msg, 0, 32);
@@ -2168,7 +2168,7 @@ void run_ecdsa_edge_cases(void) {
 }
 
 #ifdef ENABLE_OPENSSL_TESTS
-EC_KEY *get_openssl_key(const secp256k1_scalar_t *key) {
+EC_KEY *get_openssl_key(const secp256k1_scalar *key) {
     unsigned char privkey[300];
     size_t privkeylen;
     const unsigned char* pbegin = privkey;
@@ -2181,12 +2181,12 @@ EC_KEY *get_openssl_key(const secp256k1_scalar_t *key) {
 }
 
 void test_ecdsa_openssl(void) {
-    secp256k1_gej_t qj;
-    secp256k1_ge_t q;
-    secp256k1_scalar_t sigr, sigs;
-    secp256k1_scalar_t one;
-    secp256k1_scalar_t msg2;
-    secp256k1_scalar_t key, msg;
+    secp256k1_gej qj;
+    secp256k1_ge q;
+    secp256k1_scalar sigr, sigs;
+    secp256k1_scalar one;
+    secp256k1_scalar msg2;
+    secp256k1_scalar key, msg;
     EC_KEY *ec_key;
     unsigned int sigsize = 80;
     size_t secp_sigsize = 80;

--- a/src/util.h
+++ b/src/util.h
@@ -18,9 +18,9 @@
 typedef struct {
     void (*fn)(const char *text, void* data);
     const void* data;
-} callback_t;
+} secp256k1_callback;
 
-static SECP256K1_INLINE void secp256k1_callback(const callback_t * const cb, const char * const text) {
+static SECP256K1_INLINE void secp256k1_callback_call(const secp256k1_callback * const cb, const char * const text) {
     cb->fn(text, (void*)cb->data);
 }
 
@@ -65,10 +65,10 @@ static SECP256K1_INLINE void secp256k1_callback(const callback_t * const cb, con
 #define VERIFY_SETUP(stmt)
 #endif
 
-static SECP256K1_INLINE void *checked_malloc(const callback_t* cb, size_t size) {
+static SECP256K1_INLINE void *checked_malloc(const secp256k1_callback* cb, size_t size) {
     void *ret = malloc(size);
     if (ret == NULL) {
-        secp256k1_callback(cb, "Out of memory");
+        secp256k1_callback_call(cb, "Out of memory");
     }
     return ret;
 }


### PR DESCRIPTION
Fixes #198.

Builds on top of #293.

Mechanical application of

`
for A in include/*.h src/*.h src/*.c src/modules/*/*.h; do sed -e 's/secp256k1_\([a-z_]*\)_t\([^a-zA-Z]\)/secp256k1_\1\2/g' <$A >/tmp/bla; mv /tmp/bla $A; sed -e 's/callback_t/secp256k1_callback/g' <$A >/tmp/bla; mv /tmp/bla $A; done
`