### PR TITLE
Eliminate a few unbraced statements that crept into the code.

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -20,7 +20,9 @@ static double gettimedouble(void) {
 void print_number(double x) {
     double y = x;
     int c = 0;
-    if (y < 0.0) y = -y;
+    if (y < 0.0) {
+        y = -y;
+    }
     while (y < 100.0) {
         y *= 10.0;
         c++;
@@ -35,13 +37,21 @@ void run_benchmark(char *name, void (*benchmark)(void*), void (*setup)(void*), v
     double max = 0.0;
     for (i = 0; i < count; i++) {
         double begin, total;
-        if (setup) setup(data);
+        if (setup) {
+            setup(data);
+        }
         begin = gettimedouble();
         benchmark(data);
         total = gettimedouble() - begin;
-        if (teardown) teardown(data);
-        if (total < min) min = total;
-        if (total > max) max = total;
+        if (teardown) {
+            teardown(data);
+        }
+        if (total < min) {
+            min = total;
+        }
+        if (total > max) {
+            max = total;
+        }
         sum += total;
     }
     printf("%s: min ", name);

--- a/src/bench_ecdh.c
+++ b/src/bench_ecdh.c
@@ -29,7 +29,9 @@ static void bench_ecdh_setup(void* arg) {
     };
 
     data->ctx = secp256k1_context_create(0);
-    for (i = 0; i < 32; i++) data->scalar[i] = i + 1;
+    for (i = 0; i < 32; i++) {
+        data->scalar[i] = i + 1;
+    }
     CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->point, point, sizeof(point)) == 1);
 }
 

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -307,7 +307,9 @@ int have_flag(int argc, char** argv, char *flag) {
         return 1;
     }
     while (argv != NULL && argv != argm) {
-        if (strcmp(*argv, flag) == 0) return 1;
+        if (strcmp(*argv, flag) == 0) {
+            return 1;
+        }
         argv++;
     }
     return 0;

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -40,8 +40,12 @@ void bench_recover_setup(void* arg) {
     int i;
     bench_recover_t *data = (bench_recover_t*)arg;
 
-    for (i = 0; i < 32; i++) data->msg[i] = 1 + i;
-    for (i = 0; i < 64; i++) data->sig[i] = 65 + i;
+    for (i = 0; i < 32; i++) {
+        data->msg[i] = 1 + i;
+    }
+    for (i = 0; i < 64; i++) {
+        data->sig[i] = 65 + i;
+    }
 }
 
 int main(void) {

--- a/src/bench_schnorr_verify.c
+++ b/src/bench_schnorr_verify.c
@@ -30,10 +30,14 @@ static void benchmark_schnorr_init(void* arg) {
     int i, k;
     benchmark_schnorr_verify_t* data = (benchmark_schnorr_verify_t*)arg;
 
-    for (i = 0; i < 32; i++) data->msg[i] = 1 + i;
+    for (i = 0; i < 32; i++) {
+        data->msg[i] = 1 + i;
+    }
     for (k = 0; k < data->numsigs; k++) {
         secp256k1_pubkey_t pubkey;
-        for (i = 0; i < 32; i++) data->sigs[k].key[i] = 33 + i + k;
+        for (i = 0; i < 32; i++) {
+            data->sigs[k].key[i] = 33 + i + k;
+        }
         secp256k1_schnorr_sign(data->ctx, data->sigs[k].sig, data->msg, data->sigs[k].key, NULL, NULL);
         data->sigs[k].pubkeylen = 33;
         CHECK(secp256k1_ec_pubkey_create(data->ctx, &pubkey, data->sigs[k].key));

--- a/src/bench_sign.c
+++ b/src/bench_sign.c
@@ -18,8 +18,12 @@ static void bench_sign_setup(void* arg) {
     int i;
     bench_sign_t *data = (bench_sign_t*)arg;
 
-    for (i = 0; i < 32; i++) data->msg[i] = i + 1;
-    for (i = 0; i < 32; i++) data->key[i] = i + 65;
+    for (i = 0; i < 32; i++) {
+        data->msg[i] = i + 1;
+    }
+    for (i = 0; i < 32; i++) {
+        data->key[i] = i + 65;
+    }
 }
 
 static void bench_sign(void* arg) {

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -48,8 +48,12 @@ int main(void) {
 
     data.ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
-    for (i = 0; i < 32; i++) data.msg[i] = 1 + i;
-    for (i = 0; i < 32; i++) data.key[i] = 33 + i;
+    for (i = 0; i < 32; i++) {
+        data.msg[i] = 1 + i;
+    }
+    for (i = 0; i < 32; i++) {
+        data.key[i] = 33 + i;
+    }
     data.siglen = 72;
     CHECK(secp256k1_ecdsa_sign(data.ctx, &sig, data.msg, data.key, NULL, NULL));
     CHECK(secp256k1_ecdsa_signature_serialize_der(data.ctx, data.sig, &data.siglen, &sig));

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -85,25 +85,26 @@ secp256k1_context_t* secp256k1_context_clone(const secp256k1_context_t* ctx) {
 }
 
 void secp256k1_context_destroy(secp256k1_context_t* ctx) {
-    if (!ctx)
-        return;
+    if (ctx) {
+        secp256k1_ecmult_context_clear(&ctx->ecmult_ctx);
+        secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);
 
-    secp256k1_ecmult_context_clear(&ctx->ecmult_ctx);
-    secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);
-
-    free(ctx);
+        free(ctx);
+    }
 }
 
 void secp256k1_context_set_illegal_callback(secp256k1_context_t* ctx, void (*fun)(const char* message, void* data), const void* data) {
-    if (!fun)
+    if (!fun) {
         fun = default_illegal_callback_fn;
+    }
     ctx->illegal_callback.fn = fun;
     ctx->illegal_callback.data = data;
 }
 
 void secp256k1_context_set_error_callback(secp256k1_context_t* ctx, void (*fun)(const char* message, void* data), const void* data) {
-    if (!fun)
+    if (!fun) {
         fun = default_error_callback_fn;
+    }
     ctx->error_callback.fn = fun;
     ctx->error_callback.data = data;
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -1591,8 +1591,9 @@ void test_constant_wnaf(const secp256k1_scalar_t *number, int w) {
     secp256k1_scalar_set_int(&shift, 1 << w);
     /* With USE_ENDOMORPHISM on we only consider 128-bit numbers */
 #ifdef USE_ENDOMORPHISM
-    for (i = 0; i < 16; ++i)
+    for (i = 0; i < 16; ++i) {
         secp256k1_scalar_shr_int(&num, 8);
+    }
     skew = secp256k1_wnaf_const(wnaf, num, w);
 #else
     secp256k1_wnaf_const(wnaf, num, w);
@@ -1733,10 +1734,12 @@ void test_scalar_split(void) {
     secp256k1_scalar_split_lambda(&s1, &slam, &full);
 
     /* check that both are <= 128 bits in size */
-    if (secp256k1_scalar_is_high(&s1))
+    if (secp256k1_scalar_is_high(&s1)) {
         secp256k1_scalar_negate(&s1, &s1);
-    if (secp256k1_scalar_is_high(&slam))
+    }
+    if (secp256k1_scalar_is_high(&slam)) {
         secp256k1_scalar_negate(&slam, &slam);
+    }
 
     secp256k1_scalar_get_b32(tmp, &s1);
     CHECK(memcmp(zero, tmp, 16) == 0);


### PR DESCRIPTION
Also avoids some easily avoided multiple-returns.