### PR TITLE
Use explicit symbol visibility.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,14 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
       CFLAGS="$saved_CFLAGS"
     ])
 
+saved_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -fvisibility=hidden"
+AC_MSG_CHECKING([if ${CC} supports -fvisibility=hidden])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+    [ AC_MSG_RESULT([yes]) ],
+    [ AC_MSG_RESULT([no])
+      CFLAGS="$saved_CFLAGS"
+    ])
 
 AC_ARG_ENABLE(benchmark,
     AS_HELP_STRING([--enable-benchmark],[compile benchmark (default is no)]),

--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -119,6 +119,20 @@ typedef int (*secp256k1_nonce_function)(
 #  define SECP256K1_INLINE inline
 # endif
 
+#ifndef SECP256K1_API
+# if defined(_WIN32)
+#  ifdef SECP256K1_BUILD
+#   define SECP256K1_API __declspec(dllexport)
+#  else
+#   define SECP256K1_API
+#  endif
+# elif defined(__GNUC__) && defined(SECP256K1_BUILD)
+#  define SECP256K1_API __attribute__ ((visibility ("default")))
+# else
+#  define SECP256K1_API
+# endif
+#endif
+
 /**Warning attributes
   * NONNULL is not used if SECP256K1_BUILD is set to avoid the compiler optimizing out
   * some paranoid null checks. */
@@ -145,7 +159,7 @@ typedef int (*secp256k1_nonce_function)(
  *  Returns: a newly created context object.
  *  In:      flags: which parts of the context to initialize.
  */
-secp256k1_context* secp256k1_context_create(
+SECP256K1_API secp256k1_context* secp256k1_context_create(
     unsigned int flags
 ) SECP256K1_WARN_UNUSED_RESULT;
 
@@ -154,7 +168,7 @@ secp256k1_context* secp256k1_context_create(
  *  Returns: a newly created context object.
  *  Args:    ctx: an existing context to copy (cannot be NULL)
  */
-secp256k1_context* secp256k1_context_clone(
+SECP256K1_API secp256k1_context* secp256k1_context_clone(
     const secp256k1_context* ctx
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_WARN_UNUSED_RESULT;
 
@@ -163,7 +177,7 @@ secp256k1_context* secp256k1_context_clone(
  *  The context pointer may not be used afterwards.
  *  Args:   ctx: an existing context to destroy (cannot be NULL)
  */
-void secp256k1_context_destroy(
+SECP256K1_API void secp256k1_context_destroy(
     secp256k1_context* ctx
 );
 
@@ -187,7 +201,7 @@ void secp256k1_context_destroy(
  *              (NULL restores a default handler that calls abort).
  *        data: the opaque pointer to pass to fun above.
  */
-void secp256k1_context_set_illegal_callback(
+SECP256K1_API void secp256k1_context_set_illegal_callback(
     secp256k1_context* ctx,
     void (*fun)(const char* message, void* data),
     const void* data
@@ -209,7 +223,7 @@ void secp256k1_context_set_illegal_callback(
  *              handler that calls abort).
  *        data: the opaque pointer to pass to fun above.
  */
-void secp256k1_context_set_error_callback(
+SECP256K1_API void secp256k1_context_set_error_callback(
     secp256k1_context* ctx,
     void (*fun)(const char* message, void* data),
     const void* data
@@ -229,7 +243,7 @@ void secp256k1_context_set_error_callback(
  *  0x03), uncompressed (65 bytes, header byte 0x04), or hybrid (65 bytes, header
  *  byte 0x06 or 0x07) format public keys.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
     const secp256k1_context* ctx,
     secp256k1_pubkey* pubkey,
     const unsigned char *input,
@@ -249,7 +263,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
  *        flags:      SECP256K1_EC_COMPRESSED if serialization should be in
  *                    compressed format.
  */
-int secp256k1_ec_pubkey_serialize(
+SECP256K1_API int secp256k1_ec_pubkey_serialize(
     const secp256k1_context* ctx,
     unsigned char *output,
     size_t *outputlen,
@@ -267,7 +281,7 @@ int secp256k1_ec_pubkey_serialize(
  *
  *  Note that this function also supports some violations of DER and even BER.
  */
-int secp256k1_ecdsa_signature_parse_der(
+SECP256K1_API int secp256k1_ecdsa_signature_parse_der(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature* sig,
     const unsigned char *input,
@@ -285,7 +299,7 @@ int secp256k1_ecdsa_signature_parse_der(
  *                     if 0 was returned).
  *  In:     sig:       a pointer to an initialized signature object
  */
-int secp256k1_ecdsa_signature_serialize_der(
+SECP256K1_API int secp256k1_ecdsa_signature_serialize_der(
     const secp256k1_context* ctx,
     unsigned char *output,
     size_t *outputlen,
@@ -301,7 +315,7 @@ int secp256k1_ecdsa_signature_serialize_der(
  *           msg32:     the 32-byte message hash being verified (cannot be NULL)
  *           pubkey:    pointer to an initialized public key to verify with (cannot be NULL)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_verify(
     const secp256k1_context* ctx,
     const secp256k1_ecdsa_signature *sig,
     const unsigned char *msg32,
@@ -355,7 +369,7 @@ extern const secp256k1_nonce_function secp256k1_nonce_function_default;
  * schemes will also accept various non-unique encodings, so care should
  * be taken when this property is required for an application.
  */
-int secp256k1_ecdsa_sign(
+SECP256K1_API int secp256k1_ecdsa_sign(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature *sig,
     const unsigned char *msg32,
@@ -371,7 +385,7 @@ int secp256k1_ecdsa_sign(
  *  Args:    ctx: pointer to a context object (cannot be NULL)
  *  In:      seckey: pointer to a 32-byte secret key (cannot be NULL)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(
     const secp256k1_context* ctx,
     const unsigned char *seckey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2);
@@ -384,7 +398,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_seckey_verify(
  *  Out:    pubkey:     pointer to the created public key (cannot be NULL)
  *  In:     seckey:     pointer to a 32-byte private key (cannot be NULL)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const unsigned char *seckey
@@ -410,7 +424,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
  *  Note that this function does not guarantee correct DER output. It is
  *  guaranteed to be parsable by secp256k1_ec_privkey_import.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_export(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_export(
     const secp256k1_context* ctx,
     unsigned char *privkey,
     size_t *privkeylen,
@@ -432,7 +446,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_export(
  * only if you know in advance it is supposed to contain a secp256k1 private
  * key.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_import(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_import(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *privkey,
@@ -448,7 +462,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_import(
  * In/Out:  seckey: pointer to a 32-byte private key.
  * In:      tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak
@@ -464,7 +478,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_add(
  * In/Out:  pubkey: pointer to a public key object.
  * In:      tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const unsigned char *tweak
@@ -477,7 +491,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_add(
  * In/Out: seckey: pointer to a 32-byte private key.
  * In:     tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak
@@ -491,7 +505,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_privkey_tweak_mul(
  * In/Out:  pubkey: pointer to a public key obkect.
  * In:      tweak:  pointer to a 32-byte tweak.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const unsigned char *tweak
@@ -503,7 +517,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_tweak_mul(
  *  Args:    ctx:       pointer to a context object (cannot be NULL)
  *  In:      seed32:    pointer to a 32-byte random seed (NULL resets to initial state)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
     secp256k1_context* ctx,
     const unsigned char *seed32
 ) SECP256K1_ARG_NONNULL(1);
@@ -519,7 +533,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_context_randomize(
  *  Use secp256k1_ec_pubkey_compress and secp256k1_ec_pubkey_decompress if the
  *  uncompressed format is needed.
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
     const secp256k1_context* ctx,
     secp256k1_pubkey *out,
     const secp256k1_pubkey * const * ins,

--- a/include/secp256k1_ecdh.h
+++ b/include/secp256k1_ecdh.h
@@ -16,7 +16,7 @@ extern "C" {
  *  In:      point:    pointer to a public point
  *           scalar:   a 32-byte scalar with which to multiply the point
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh(
   const secp256k1_context* ctx,
   unsigned char *result,
   const secp256k1_pubkey *point,

--- a/include/secp256k1_recovery.h
+++ b/include/secp256k1_recovery.h
@@ -33,7 +33,7 @@ typedef struct {
  *  In:   input64: a pointer to a 64-byte compact signature
  *        recid:   the recovery id (0, 1, 2 or 3)
  */
-int secp256k1_ecdsa_recoverable_signature_parse_compact(
+SECP256K1_API int secp256k1_ecdsa_recoverable_signature_parse_compact(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_recoverable_signature* sig,
     const unsigned char *input64,
@@ -46,7 +46,7 @@ int secp256k1_ecdsa_recoverable_signature_parse_compact(
  *  Out: sig:    a pointer to a normal signature (cannot be NULL).
  *  In:  sigin:  a pointer to a recoverable signature (cannot be NULL).
  */
-int secp256k1_ecdsa_recoverable_signature_convert(
+SECP256K1_API int secp256k1_ecdsa_recoverable_signature_convert(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_signature* sig,
     const secp256k1_ecdsa_recoverable_signature* sigin
@@ -60,7 +60,7 @@ int secp256k1_ecdsa_recoverable_signature_convert(
  *        recid:    a pointer to an integer to hold the recovery id (can be NULL).
  *  In:   sig:      a pointer to an initialized signature object (cannot be NULL)
  */
-int secp256k1_ecdsa_recoverable_signature_serialize_compact(
+SECP256K1_API int secp256k1_ecdsa_recoverable_signature_serialize_compact(
     const secp256k1_context* ctx,
     unsigned char *output64,
     int *recid,
@@ -78,7 +78,7 @@ int secp256k1_ecdsa_recoverable_signature_serialize_compact(
  *           noncefp:pointer to a nonce generation function. If NULL, secp256k1_nonce_function_default is used
  *           ndata:  pointer to arbitrary data used by the nonce generation function (can be NULL)
  */
-int secp256k1_ecdsa_sign_recoverable(
+SECP256K1_API int secp256k1_ecdsa_sign_recoverable(
     const secp256k1_context* ctx,
     secp256k1_ecdsa_recoverable_signature *sig,
     const unsigned char *msg32,
@@ -96,7 +96,7 @@ int secp256k1_ecdsa_sign_recoverable(
  *  In:      sig:        pointer to initialized signature that supports pubkey recovery (cannot be NULL)
  *           msg32:      the 32-byte message hash assumed to be signed (cannot be NULL)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdsa_recover(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const secp256k1_ecdsa_recoverable_signature *sig,

--- a/include/secp256k1_schnorr.h
+++ b/include/secp256k1_schnorr.h
@@ -94,7 +94,7 @@ int secp256k1_schnorr_generate_nonce_pair(
   const unsigned char *sec32,
   secp256k1_nonce_function noncefp,
   const void* noncedata
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(6) SECP256K1_ARG_NONNULL(7);
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 /** Produce a partial Schnorr signature, which can be combined using
  *  secp256k1_schnorr_partial_combine, to end up with a full signature that is

--- a/include/secp256k1_schnorr.h
+++ b/include/secp256k1_schnorr.h
@@ -24,7 +24,7 @@ extern "C" {
  *           ndata:  pointer to arbitrary data used by the nonce generation
  *                   function (can be NULL)
  */
-int secp256k1_schnorr_sign(
+SECP256K1_API int secp256k1_schnorr_sign(
   const secp256k1_context* ctx,
   unsigned char *sig64,
   const unsigned char *msg32,
@@ -41,7 +41,7 @@ int secp256k1_schnorr_sign(
  *           msg32:     the 32-byte message hash being verified (cannot be NULL)
  *           pubkey:    the public key to verify with (cannot be NULL)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
   const secp256k1_context* ctx,
   const unsigned char *sig64,
   const unsigned char *msg32,
@@ -61,7 +61,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
  *           msg32:      the 32-byte message hash assumed to be signed (cannot
  *                       be NULL)
  */
-int secp256k1_schnorr_recover(
+SECP256K1_API int secp256k1_schnorr_recover(
   const secp256k1_context* ctx,
   secp256k1_pubkey *pubkey,
   const unsigned char *sig64,
@@ -86,7 +86,7 @@ int secp256k1_schnorr_recover(
  *
  *  Do not use the output as a private/public key pair for signing/validation.
  */
-int secp256k1_schnorr_generate_nonce_pair(
+SECP256K1_API int secp256k1_schnorr_generate_nonce_pair(
   const secp256k1_context* ctx,
   secp256k1_pubkey *pubnonce,
   unsigned char *privnonce32,
@@ -138,7 +138,7 @@ int secp256k1_schnorr_generate_nonce_pair(
  *  pre-combine several inputs already with one call, and add more inputs later
  *  by calling the function again (they are commutative and associative).
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_sign(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_sign(
   const secp256k1_context* ctx,
   unsigned char *sig64,
   const unsigned char *msg32,
@@ -159,7 +159,7 @@ SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_sign(
  *                   signatures
  *         n:        the number of signatures to combine (at least 1)
  */
-SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_combine(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_combine(
   const secp256k1_context* ctx,
   unsigned char *sig64,
   const unsigned char * const * sig64sin,

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -7,6 +7,7 @@
 #ifndef _SECP256K1_MODULE_ECDH_MAIN_
 #define _SECP256K1_MODULE_ECDH_MAIN_
 
+#include "include/secp256k1_ecdh.h"
 #include "ecmult_const_impl.h"
 
 int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar) {

--- a/src/modules/schnorr/main_impl.h
+++ b/src/modules/schnorr/main_impl.h
@@ -7,6 +7,7 @@
 #ifndef SECP256K1_MODULE_SCHNORR_MAIN
 #define SECP256K1_MODULE_SCHNORR_MAIN
 
+#include "include/secp256k1_schnorr.h"
 #include "modules/schnorr/schnorr_impl.h"
 
 static void secp256k1_schnorr_msghash_sha256(unsigned char *h32, const unsigned char *r32, const unsigned char *msg32) {

--- a/src/modules/schnorr/schnorr.h
+++ b/src/modules/schnorr/schnorr.h
@@ -4,8 +4,8 @@
  * file COPYING or http://www.opensource.org/licenses/mit-license.php. *
  ***********************************************************************/
 
-#ifndef _SECP256K1_SCHNORR_
-#define _SECP256K1_SCHNORR_
+#ifndef _SECP256K1_MODULE_SCHNORR_H_
+#define _SECP256K1_MODULE_SCHNORR_H_
 
 #include "scalar.h"
 #include "group.h"

--- a/src/modules/schnorr/tests_impl.h
+++ b/src/modules/schnorr/tests_impl.h
@@ -7,6 +7,8 @@
 #ifndef SECP256K1_MODULE_SCHNORR_TESTS
 #define SECP256K1_MODULE_SCHNORR_TESTS
 
+#include "include/secp256k1_schnorr.h"
+
 void test_schnorr_end_to_end(void) {
     unsigned char privkey[32];
     unsigned char message[32];


### PR DESCRIPTION
The use of static makes this somewhat redundant currently, though if
we later have multiple compilation units it will be needed.

This also sets the dllexport needed for shared libraries on win32.
