### PR TITLE
Use the explicit NULL macro for pointer comparisons.

### DIFF
--- a/src/bench.h
+++ b/src/bench.h
@@ -37,13 +37,13 @@ void run_benchmark(char *name, void (*benchmark)(void*), void (*setup)(void*), v
     double max = 0.0;
     for (i = 0; i < count; i++) {
         double begin, total;
-        if (setup) {
+        if (setup != NULL) {
             setup(data);
         }
         begin = gettimedouble();
         benchmark(data);
         total = gettimedouble() - begin;
-        if (teardown) {
+        if (teardown != NULL) {
             teardown(data);
         }
         if (total < min) {

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -159,7 +159,7 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
     secp256k1_rfc6979_hmac_sha256_t rng;
     int retry;
     unsigned char keydata[64] = {0};
-    if (!seed32) {
+    if (seed32 == NULL) {
         /* When seed is NULL, reset the initial point and blinding value. */
         secp256k1_gej_set_ge(&ctx->initial, &secp256k1_ge_const_g);
         secp256k1_gej_neg(&ctx->initial, &ctx->initial);
@@ -172,7 +172,7 @@ static void secp256k1_ecmult_gen_blind(secp256k1_ecmult_gen_context *ctx, const 
      *   asking the caller for blinding values directly and expecting them to retry on failure.
      */
     memcpy(keydata, nonce32, 32);
-    if (seed32) {
+    if (seed32 != NULL) {
         memcpy(keydata + 32, seed32, 32);
     }
     secp256k1_rfc6979_hmac_sha256_initialize(&rng, keydata, seed32 ? 64 : 32);

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -265,13 +265,13 @@ static void secp256k1_gej_double_var(secp256k1_gej *r, const secp256k1_gej *a, s
      */
     r->infinity = a->infinity;
     if (r->infinity) {
-        if (rzr) {
+        if (rzr != NULL) {
             secp256k1_fe_set_int(rzr, 1);
         }
         return;
     }
 
-    if (rzr) {
+    if (rzr != NULL) {
         *rzr = a->y;
         secp256k1_fe_normalize_weak(rzr);
         secp256k1_fe_mul_int(rzr, 2);
@@ -315,7 +315,7 @@ static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, cons
     }
 
     if (b->infinity) {
-        if (rzr) {
+        if (rzr != NULL) {
             secp256k1_fe_set_int(rzr, 1);
         }
         *r = *a;
@@ -335,7 +335,7 @@ static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, cons
         if (secp256k1_fe_normalizes_to_zero_var(&i)) {
             secp256k1_gej_double_var(r, a, rzr);
         } else {
-            if (rzr) {
+            if (rzr != NULL) {
                 secp256k1_fe_set_int(rzr, 0);
             }
             r->infinity = 1;
@@ -346,7 +346,7 @@ static void secp256k1_gej_add_var(secp256k1_gej *r, const secp256k1_gej *a, cons
     secp256k1_fe_sqr(&h2, &h);
     secp256k1_fe_mul(&h3, &h, &h2);
     secp256k1_fe_mul(&h, &h, &b->z);
-    if (rzr) {
+    if (rzr != NULL) {
         *rzr = h;
     }
     secp256k1_fe_mul(&r->z, &a->z, &h);
@@ -366,7 +366,7 @@ static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, c
         return;
     }
     if (b->infinity) {
-        if (rzr) {
+        if (rzr != NULL) {
             secp256k1_fe_set_int(rzr, 1);
         }
         *r = *a;
@@ -385,7 +385,7 @@ static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, c
         if (secp256k1_fe_normalizes_to_zero_var(&i)) {
             secp256k1_gej_double_var(r, a, rzr);
         } else {
-            if (rzr) {
+            if (rzr != NULL) {
                 secp256k1_fe_set_int(rzr, 0);
             }
             r->infinity = 1;
@@ -395,7 +395,7 @@ static void secp256k1_gej_add_ge_var(secp256k1_gej *r, const secp256k1_gej *a, c
     secp256k1_fe_sqr(&i2, &i);
     secp256k1_fe_sqr(&h2, &h);
     secp256k1_fe_mul(&h3, &h, &h2);
-    if (rzr) {
+    if (rzr != NULL) {
         *rzr = h;
     }
     secp256k1_fe_mul(&r->z, &a->z, &h);

--- a/src/modules/schnorr/schnorr_impl.h
+++ b/src/modules/schnorr/schnorr_impl.h
@@ -73,7 +73,7 @@ static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context* ctx, u
     n = *nonce;
 
     secp256k1_ecmult_gen(ctx, &Rj, &n);
-    if (pubnonce) {
+    if (pubnonce != NULL) {
         secp256k1_gej_add_ge(&Rj, &Rj, pubnonce);
     }
     secp256k1_ge_set_gej(&Ra, &Rj);

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -85,7 +85,7 @@ secp256k1_context* secp256k1_context_clone(const secp256k1_context* ctx) {
 }
 
 void secp256k1_context_destroy(secp256k1_context* ctx) {
-    if (ctx) {
+    if (ctx != NULL) {
         secp256k1_ecmult_context_clear(&ctx->ecmult_ctx);
         secp256k1_ecmult_gen_context_clear(&ctx->ecmult_gen_ctx);
 
@@ -94,7 +94,7 @@ void secp256k1_context_destroy(secp256k1_context* ctx) {
 }
 
 void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
-    if (!fun) {
+    if (fun == NULL) {
         fun = default_illegal_callback_fn;
     }
     ctx->illegal_callback.fn = fun;
@@ -102,7 +102,7 @@ void secp256k1_context_set_illegal_callback(secp256k1_context* ctx, void (*fun)(
 }
 
 void secp256k1_context_set_error_callback(secp256k1_context* ctx, void (*fun)(const char* message, void* data), const void* data) {
-    if (!fun) {
+    if (fun == NULL) {
         fun = default_error_callback_fn;
     }
     ctx->error_callback.fn = fun;

--- a/src/tests.c
+++ b/src/tests.c
@@ -2198,7 +2198,7 @@ void test_ecdsa_openssl(void) {
     secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &qj, &key);
     secp256k1_ge_set_gej(&q, &qj);
     ec_key = get_openssl_key(&key);
-    CHECK(ec_key);
+    CHECK(ec_key != NULL);
     CHECK(ECDSA_sign(0, message, sizeof(message), signature, &sigsize, ec_key));
     CHECK(secp256k1_ecdsa_sig_parse(&sigr, &sigs, signature, sigsize));
     CHECK(secp256k1_ecdsa_sig_verify(&ctx->ecmult_ctx, &sigr, &sigs, &q, &msg));
@@ -2257,7 +2257,7 @@ int main(int argc, char **argv) {
         }
     } else {
         FILE *frand = fopen("/dev/urandom", "r");
-        if (!frand || !fread(&seed16, sizeof(seed16), 1, frand)) {
+        if ((frand == NULL) || !fread(&seed16, sizeof(seed16), 1, frand)) {
             uint64_t t = time(NULL) * (uint64_t)1337;
             seed16[0] ^= t;
             seed16[1] ^= t >> 8;


### PR DESCRIPTION
This makes it more clear that a null check is intended. Avoiding the
 use of a pointer as a test condition alse increases the type-safety
 of the comparisons.

(This is also MISRA C 2012 rules 14.4 and 11.9)