### PR TITLE
[Schnorr API BREAK] Improve Schnorr multisigning API + refactoring

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -537,7 +537,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_combine(
     const secp256k1_context* ctx,
     secp256k1_pubkey *out,
     const secp256k1_pubkey * const * ins,
-    int n
+    size_t n
 ) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 # ifdef __cplusplus

--- a/include/secp256k1_schnorr.h
+++ b/include/secp256k1_schnorr.h
@@ -7,9 +7,12 @@
 extern "C" {
 # endif
 
-/** Create a signature using a custom EC-Schnorr-SHA256 construction. It
- *  produces non-malleable 64-byte signatures which support public key recovery
- *  batch validation, and multiparty signing.
+/** This header file defines an API for a custom EC-Schnorr-SHA256 constructions.
+ *  It supports non-malleable 64-byte signatures which support public key
+ *  recovery, batch validation, and multiparty signing.
+ */
+
+/** Create a single party Schnorr signature.
  *  Returns: 1: signature created
  *           0: the nonce generation function failed, or the private key was
  *              invalid.
@@ -33,13 +36,16 @@ SECP256K1_API int secp256k1_schnorr_sign(
   const void *ndata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
-/** Verify a signature created by secp256k1_schnorr_sign.
+/** Verify a Schnorr signature.
  *  Returns: 1: correct signature
  *           0: incorrect signature
  *  Args:    ctx:       a secp256k1 context object, initialized for verification.
  *  In:      sig64:     the 64-byte signature being verified (cannot be NULL)
  *           msg32:     the 32-byte message hash being verified (cannot be NULL)
  *           pubkey:    the public key to verify with (cannot be NULL)
+ *
+ *  Signatures verifiable by this function can be created using
+ *  secp256k1_schnorr_sign, or secp256k1_schnorr_multisign_combine.
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
   const secp256k1_context* ctx,
@@ -48,8 +54,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
   const secp256k1_pubkey *pubkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
-/** Recover an EC public key from a Schnorr signature created using
- *  secp256k1_schnorr_sign.
+/** Recover an EC public key from a Schnorr signature.
  *  Returns: 1: public key successfully recovered (which guarantees a correct
  *           signature).
  *           0: otherwise.
@@ -60,6 +65,9 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_verify(
  *  In:      sig64:      signature as 64 byte array (cannot be NULL)
  *           msg32:      the 32-byte message hash assumed to be signed (cannot
  *                       be NULL)
+ *
+ *  Signatures recoverable by this function can be created using
+ *  secp256k1_schnorr_sign, or secp256k1_schnorr_multisign_combine.
  */
 SECP256K1_API int secp256k1_schnorr_recover(
   const secp256k1_context* ctx,
@@ -68,102 +76,123 @@ SECP256K1_API int secp256k1_schnorr_recover(
   const unsigned char *msg32
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
-/** Generate a nonce pair deterministically for use with
- *  secp256k1_schnorr_partial_sign.
- *  Returns: 1: valid nonce pair was generated.
- *           0: otherwise (nonce generation function failed)
- *  Args:    ctx:         pointer to a context object, initialized for signing
- *                        (cannot be NULL)
- *  Out:     pubnonce:    public side of the nonce (cannot be NULL)
- *           privnonce32: private side of the nonce (32 byte) (cannot be NULL)
- *  In:      msg32:       the 32-byte message hash assumed to be signed (cannot
- *                        be NULL)
- *           sec32:       the 32-byte private key (cannot be NULL)
- *           noncefp:     pointer to a nonce generation function. If NULL,
- *                        secp256k1_nonce_function_default is used
- *           noncedata:   pointer to arbitrary data used by the nonce generation
- *                        function (can be NULL)
+/** Produce a 96-byte first stage partial multisignature.
+ *  Returns: 1: a first stage partial signature was created
+ *           0: otherwise (nonce generation failed, invalid private key, or
+ *              a very unlikely unsignable combination)
+ *  Args:    ctx:       pointer to a context object, initialized for signing
+ *                      (cannot be NULL)
+ *  Out:     stage1sig96: pointer to a 96-byte array to store the signature
+ *  In:      msg32:  the 32-byte message hash being signed (cannot be NULL)
+ *           seckey: pointer to a 32-byte secret key (cannot be NULL)
+ *           noncefp:pointer to a nonce generation function. If NULL,
+ *                   secp256k1_nonce_function_default is used
+ *           ndata:  pointer to arbitrary data used by the nonce generation
+ *                   function (can be NULL)
  *
- *  Do not use the output as a private/public key pair for signing/validation.
+ *  All cosigners must use the same msg32, but may use different nonce
+ *  generation parameters.
+ *
+ *  The purpose of the stage 1 round is establishing a shared public nonce that
+ *  all cosigners agree on (without revealing their secret nonces), and proving
+ *  access to their private keys.
+ *
+ *  Internal details:
+ *    The 96-byte structure consists of:
+ *    - 32-byte serialization of the R.x coordinate that would be used in a
+ *      normal signature of msg32 using key sec32
+ *    - a 64-byte normal signature of SHA256(R || msg32) using key sec32
  */
-SECP256K1_API int secp256k1_schnorr_generate_nonce_pair(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_multisign_stage1(
   const secp256k1_context* ctx,
-  secp256k1_pubkey *pubnonce,
-  unsigned char *privnonce32,
+  unsigned char *stage1sig96,
   const unsigned char *msg32,
   const unsigned char *sec32,
   secp256k1_nonce_function noncefp,
   const void* noncedata
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
-/** Produce a partial Schnorr signature, which can be combined using
- *  secp256k1_schnorr_partial_combine, to end up with a full signature that is
- *  verifiable using secp256k1_schnorr_verify.
- *  Returns: 1: signature created succesfully.
- *           0: no valid signature exists with this combination of keys, nonces
- *              and message (chance around 1 in 2^128)
- *          -1: invalid private key, nonce, or public nonces.
- *  Args: ctx:             pointer to context object, initialized for signing (cannot
- *                         be NULL)
- *  Out:  sig64:           pointer to 64-byte array to put partial signature in
- *  In:   msg32:           pointer to 32-byte message to sign
- *        sec32:           pointer to 32-byte private key
- *        pubnonce_others: pointer to pubkey containing the sum of the other's
- *                         nonces (see secp256k1_ec_pubkey_combine)
- *        secnonce32:      pointer to 32-byte array containing our nonce
+/** Produce a 64-byte second stage partial multisignature.
+ *  Returns: 1: a second stage partial signature was created.
+ *           0: otherwise (nonce generation failed, invalid private key,
+ *              invalid stage 1 signatures, or a very unlikely unsignable
+ *              combination)
+ *  Args: ctx:               pointer to a context object, initialized for
+ *                           signing and verification (cannot be NULL)
+ *  Out: stage2sig64:        pointer to a 64-byte array to store the signature
+ *  In:  other_stage1sig96s: pointer to an array of num_others pointers to
+ *                           96-byte stage 1 partial multisignatures from all
+ *                           other cosigners (can only be NULL if num_others is
+ *                           0)
+ *       num_others:         the number of cosigners (excluding yourself)
+ *       msg32:              the 32-byte message hash being signed (cannot be
+ *                           NULL)
+ *       other_pubkeys:      pointer to an array of pointers to the other
+ *                           cosigners' public keys, in the same order as
+ *                           other_stage1sig96s (can only be NULL if num_others
+ *                           is 0)
+ *       sec32:              pointer to a 32-byte secret key (cannot be NULL)
+ *       noncefp:            pointer to a nonce generation function. If NULL,
+ *                           secp256k1_nonce_function_default is used
+ *       ndata:              pointer to arbitrary data used by the nonce
+ *                           generation function (can be NULL)
  *
- * The intended procedure for creating a multiparty signature is:
- * - Each signer S[i] with private key x[i] and public key Q[i] runs
- *   secp256k1_schnorr_generate_nonce_pair to produce a pair (k[i],R[i]) of
- *   private/public nonces.
- * - All signers communicate their public nonces to each other (revealing your
- *   private nonce can lead to discovery of your private key, so it should be
- *   considered secret).
- * - All signers combine all the public nonces they received (excluding their
- *   own) using secp256k1_ec_pubkey_combine to obtain an
- *   Rall[i] = sum(R[0..i-1,i+1..n]).
- * - All signers produce a partial signature using
- *   secp256k1_schnorr_partial_sign, passing in their own private key x[i],
- *   their own private nonce k[i], and the sum of the others' public nonces
- *   Rall[i].
- * - All signers communicate their partial signatures to each other.
- * - Someone combines all partial signatures using
- *   secp256k1_schnorr_partial_combine, to obtain a full signature.
- * - The resulting signature is validatable using secp256k1_schnorr_verify, with
- *   public key equal to the result of secp256k1_ec_pubkey_combine of the
- *   signers' public keys (sum(Q[0..n])).
+ *  The second stage uses the stage 1 partial signatures from all other
+ *  cosigners and computes a stage 2 partial signature. If num_others is 0, the
+ *  result is a full signature (and identical to the one produced by
+ *  secp256k1_schnorr_sign, given the same msg32, sec32, noncefp, ndata).
  *
- *  Note that secp256k1_schnorr_partial_combine and secp256k1_ec_pubkey_combine
- *  function take their arguments in any order, and it is possible to
- *  pre-combine several inputs already with one call, and add more inputs later
- *  by calling the function again (they are commutative and associative).
+ *  All cosigners must use the same msg32, and the same as in stage1. You must
+ *  also use the same noncefp/ndata for your own stage1 and stage2. Other
+ *  participants may use different nonce generation, though.
+ *
+ *  The order of stage 1 signatures in other_stage1sig96s does not matter, but
+ *  it must match that of the public keys in other_pubkeys.
+ *
+ *  Internal details:
+ *    The 64-byte structure is equal to that of a final signature:
+ *    - 32-byte serialization of the R.x coordinate that will be used by the
+ *      final signature.
+ *    - 32-byte serialization of the s value, based on the hash of the final
+ *      R.x, but using only the value of our own k value.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_sign(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_multisign_stage2(
   const secp256k1_context* ctx,
-  unsigned char *sig64,
+  unsigned char *stage2sig64,
+  const unsigned char * const * other_stage1sig96s,
+  size_t num_others,
   const unsigned char *msg32,
+  const secp256k1_pubkey * const *other_pubkeys,
   const unsigned char *sec32,
-  const secp256k1_pubkey *pubnonce_others,
-  const unsigned char *secnonce32
-) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(6);
+  secp256k1_nonce_function noncefp,
+  const void* noncedata
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(5) SECP256K1_ARG_NONNULL(7);
 
-/** Combine multiple Schnorr partial signatures.
- * Returns: 1: the passed signatures were succesfully combined.
- *          0: the resulting signature is not valid (chance of 1 in 2^256)
- *         -1: some inputs were invalid, or the signatures were not created
- *             using the same set of nonces
- * Args:   ctx:      pointer to a context object
- * Out:    sig64:    pointer to a 64-byte array to place the combined signature
- *                   (cannot be NULL)
- * In:     sig64sin: pointer to an array of n pointers to 64-byte input
- *                   signatures
- *         n:        the number of signatures to combine (at least 1)
+/** Combine multiple Schnorr stage 2 partial signatures into a full signature.
+ *  Returns: 1: the passed signatures were succesfully combined.
+ *           0: the resulting signature is not valid (chance of 1 in 2^256) or
+ *              the inputs were not created using the same set of keys
+ *  Args:   ctx:          pointer to a context object
+ *  Out:    sig64:        pointer to a 64-byte array to place the combined
+ *                        full signature (cannot be NULL)
+ *  In:     stage2sig64s: pointer to an array of n pointers to 64-byte stage 2
+ *                        partial signatures (cannot be NULL)
+ *          n:            the number of signatures to combine (at least 1)
+ *
+ *  The order of the stage 2 partial signatures in stage2sig64s does not matter.
+ *
+ *  If succesful, the resulting combined full signature will be verifiable with
+ *  secp256k1_schnorr_verify(ctx, sig64, msg32, pub), where:
+ *  - sig64 is the output of secp256k1_schnorr_multisign_combine
+ *  - msg32 is the message used by all cosigners in stage 1 and stage 2
+ *  - pub is the result of secp256k1_ec_pubkey_combine, applied to all
+ *    cosigners' public keys.
  */
-SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_partial_combine(
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_multisign_combine(
   const secp256k1_context* ctx,
   unsigned char *sig64,
-  const unsigned char * const * sig64sin,
-  int n
+  const unsigned char * const * stage2sig64s,
+  size_t n
 ) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3);
 
 # ifdef __cplusplus

--- a/include/secp256k1_schnorr.h
+++ b/include/secp256k1_schnorr.h
@@ -9,7 +9,8 @@ extern "C" {
 
 /** This header file defines an API for a custom EC-Schnorr-SHA256 constructions.
  *  It supports non-malleable 64-byte signatures which support public key
- *  recovery, batch validation, and multiparty signing.
+ *  recovery, batch validation, and multiparty signing. See schnorr.md for more
+ *  details.
  */
 
 /** Create a single party Schnorr signature.
@@ -96,12 +97,6 @@ SECP256K1_API int secp256k1_schnorr_recover(
  *  The purpose of the stage 1 round is establishing a shared public nonce that
  *  all cosigners agree on (without revealing their secret nonces), and proving
  *  access to their private keys.
- *
- *  Internal details:
- *    The 96-byte structure consists of:
- *    - 32-byte serialization of the R.x coordinate that would be used in a
- *      normal signature of msg32 using key sec32
- *    - a 64-byte normal signature of SHA256(R || msg32) using key sec32
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_multisign_stage1(
   const secp256k1_context* ctx,
@@ -142,19 +137,15 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_multisign_stage
  *  result is a full signature (and identical to the one produced by
  *  secp256k1_schnorr_sign, given the same msg32, sec32, noncefp, ndata).
  *
+ *  You must make sure that the keys in other_pubkeys are those of the
+ *  cosigners you're willing to sign with.
+ *
  *  All cosigners must use the same msg32, and the same as in stage1. You must
  *  also use the same noncefp/ndata for your own stage1 and stage2. Other
  *  participants may use different nonce generation, though.
  *
  *  The order of stage 1 signatures in other_stage1sig96s does not matter, but
  *  it must match that of the public keys in other_pubkeys.
- *
- *  Internal details:
- *    The 64-byte structure is equal to that of a final signature:
- *    - 32-byte serialization of the R.x coordinate that will be used by the
- *      final signature.
- *    - 32-byte serialization of the s value, based on the hash of the final
- *      R.x, but using only the value of our own k value.
  */
 SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_schnorr_multisign_stage2(
   const secp256k1_context* ctx,

--- a/src/modules/schnorr/main_impl.h
+++ b/src/modules/schnorr/main_impl.h
@@ -88,19 +88,11 @@ int secp256k1_schnorr_recover(const secp256k1_context* ctx, secp256k1_pubkey *pu
     }
 }
 
-int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, unsigned char *privnonce32, const unsigned char *sec32, const unsigned char *msg32, secp256k1_nonce_function noncefp, const void* noncedata) {
+static int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context* ctx, secp256k1_ge *pubnonce, unsigned char *privnonce32, const unsigned char *msg32, const unsigned char *sec32, secp256k1_nonce_function noncefp, const void* noncedata) {
     int count = 0;
     int ret = 1;
     secp256k1_gej Qj;
-    secp256k1_ge Q;
     secp256k1_scalar sec;
-
-    VERIFY_CHECK(ctx != NULL);
-    ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
-    ARG_CHECK(msg32 != NULL);
-    ARG_CHECK(sec32 != NULL);
-    ARG_CHECK(pubnonce != NULL);
-    ARG_CHECK(privnonce32 != NULL);
 
     if (noncefp == NULL) {
         noncefp = secp256k1_nonce_function_default;
@@ -108,7 +100,7 @@ int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context* ctx, secp256k
 
     do {
         int overflow;
-        ret = noncefp(privnonce32, sec32, msg32, secp256k1_schnorr_algo16, (void*)noncedata, count++);
+        ret = noncefp(privnonce32, msg32, sec32, secp256k1_schnorr_algo16, (void*)noncedata, count++);
         if (!ret) {
             break;
         }
@@ -117,48 +109,120 @@ int secp256k1_schnorr_generate_nonce_pair(const secp256k1_context* ctx, secp256k
             continue;
         }
         secp256k1_ecmult_gen(&ctx->ecmult_gen_ctx, &Qj, &sec);
-        secp256k1_ge_set_gej(&Q, &Qj);
-
-        secp256k1_pubkey_save(pubnonce, &Q);
+        secp256k1_ge_set_gej(pubnonce, &Qj);
+        secp256k1_fe_normalize(&pubnonce->y);
+        if (secp256k1_fe_is_odd(&pubnonce->y)) {
+            secp256k1_scalar_negate(&sec, &sec);
+            secp256k1_scalar_get_b32(privnonce32, &sec);
+            secp256k1_ge_neg(pubnonce, pubnonce);
+        }
         break;
     } while(1);
 
     secp256k1_scalar_clear(&sec);
+    return ret;
+}
+
+int secp256k1_schnorr_multisign_stage1(const secp256k1_context* ctx, unsigned char *stage1, const unsigned char *msg32, const unsigned char *sec32, secp256k1_nonce_function noncefp, const void* noncedata) {
+    secp256k1_ge pubnonce;
+    unsigned char privnonce32[32];
+    unsigned char tmphash[32];
+    secp256k1_sha256_t sha;
+    int ret;
+
+    VERIFY_CHECK(ctx != NULL);
+    ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
+    ARG_CHECK(msg32 != NULL);
+    ARG_CHECK(sec32 != NULL);
+    ARG_CHECK(stage1 != NULL);
+
+    ret = secp256k1_schnorr_generate_nonce_pair(ctx, &pubnonce, privnonce32, msg32, sec32, noncefp, noncedata);
+    memset(privnonce32, 0, 32);
+    secp256k1_fe_normalize(&pubnonce.x);
+    secp256k1_fe_get_b32(stage1, &pubnonce.x);
+    secp256k1_sha256_initialize(&sha);
+    secp256k1_sha256_write(&sha, stage1, 32);
+    secp256k1_sha256_write(&sha, msg32, 32);
+    secp256k1_sha256_finalize(&sha, tmphash);
+    ret = ret & secp256k1_schnorr_sign(ctx, stage1 + 32, tmphash, sec32, noncefp, noncedata);
+
     if (!ret) {
-        memset(pubnonce, 0, sizeof(*pubnonce));
+        memset(stage1, 0, 96);
     }
     return ret;
 }
 
-int secp256k1_schnorr_partial_sign(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char *msg32, const unsigned char *sec32, const secp256k1_pubkey *pubnonce_others, const unsigned char *secnonce32) {
+int secp256k1_schnorr_multisign_stage2(const secp256k1_context* ctx, unsigned char *stage2, const unsigned char * const *other_stage1s, size_t num_others, const unsigned char *msg32, const secp256k1_pubkey * const *other_pubkeys, const unsigned char *sec32, secp256k1_nonce_function noncefp, const void* noncedata) {
+    int ret = 1;
     int overflow = 0;
     secp256k1_scalar sec, non;
+    secp256k1_gej pubnonj;
     secp256k1_ge pubnon;
+    secp256k1_ge pubnon_mine;
+    unsigned char privnonce32[32];
+
     VERIFY_CHECK(ctx != NULL);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
+    ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
+    ARG_CHECK(stage2 != NULL);
+    if (num_others > 0) {
+        ARG_CHECK(other_stage1s != NULL);
+        ARG_CHECK(other_pubkeys != NULL);
+        ARG_CHECK(other_stage1s[num_others - 1] != NULL);
+        ARG_CHECK(other_pubkeys[num_others - 1] != NULL);
+    }
     ARG_CHECK(msg32 != NULL);
-    ARG_CHECK(sig64 != NULL);
     ARG_CHECK(sec32 != NULL);
-    ARG_CHECK(secnonce32 != NULL);
-    ARG_CHECK(pubnonce_others != NULL);
 
     secp256k1_scalar_set_b32(&sec, sec32, &overflow);
     if (overflow || secp256k1_scalar_is_zero(&sec)) {
-        return -1;
+        return 0;
     }
-    secp256k1_scalar_set_b32(&non, secnonce32, &overflow);
-    if (overflow || secp256k1_scalar_is_zero(&non)) {
-        return -1;
+
+    if (num_others > 0) {
+        size_t n = 0;
+        while (n < num_others) {
+            secp256k1_fe fex;
+            secp256k1_sha256_t sha;
+            unsigned char tmphash[32];
+            secp256k1_sha256_initialize(&sha);
+            secp256k1_sha256_write(&sha, other_stage1s[n], 32);
+            secp256k1_sha256_write(&sha, msg32, 32);
+            secp256k1_sha256_finalize(&sha, tmphash);
+            ret = ret & secp256k1_schnorr_verify(ctx, other_stage1s[n] + 32, tmphash, other_pubkeys[n]);
+            ret = ret & secp256k1_fe_set_b32(&fex, other_stage1s[n]);
+            ret = ret & secp256k1_ge_set_xo_var(&pubnon, &fex, 0);
+            if (n) {
+                secp256k1_gej_add_ge(&pubnonj, &pubnonj, &pubnon);
+            } else {
+                secp256k1_gej_set_ge(&pubnonj, &pubnon);
+            }
+            n++;
+        }
+        if (ret) {
+            secp256k1_ge_set_gej(&pubnon, &pubnonj);
+        }
     }
-    secp256k1_pubkey_load(ctx, &pubnon, pubnonce_others);
-    return secp256k1_schnorr_sig_sign(&ctx->ecmult_gen_ctx, sig64, &sec, &non, &pubnon, secp256k1_schnorr_msghash_sha256, msg32);
+
+    ret = ret & secp256k1_schnorr_generate_nonce_pair(ctx, &pubnon_mine, privnonce32, msg32, sec32, noncefp, noncedata);
+    secp256k1_scalar_set_b32(&non, privnonce32, &overflow);
+    memset(privnonce32, 0, 32);
+    ret = ret & (overflow == 0) & !secp256k1_scalar_is_zero(&non);
+    ret = ret && secp256k1_schnorr_sig_sign(&ctx->ecmult_gen_ctx, stage2, &sec, &non, num_others > 0 ? &pubnon : NULL, secp256k1_schnorr_msghash_sha256, msg32);
+    secp256k1_scalar_clear(&sec);
+    secp256k1_scalar_clear(&non);
+    if (!ret) {
+        memset(stage2, 0, 64);
+    }
+    return ret;
 }
 
-int secp256k1_schnorr_partial_combine(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char * const *sig64sin, int n) {
+int secp256k1_schnorr_multisign_combine(const secp256k1_context* ctx, unsigned char *sig64, const unsigned char * const *stage2s, size_t n) {
     ARG_CHECK(sig64 != NULL);
     ARG_CHECK(n >= 1);
-    ARG_CHECK(sig64sin != NULL);
-    return secp256k1_schnorr_sig_combine(sig64, n, sig64sin);
+    ARG_CHECK(stage2s != NULL);
+    ARG_CHECK(stage2s[n - 1] != NULL);
+    return secp256k1_schnorr_sig_combine(sig64, n, stage2s);
 }
 
 #endif

--- a/src/modules/schnorr/schnorr.h
+++ b/src/modules/schnorr/schnorr.h
@@ -15,6 +15,6 @@ typedef void (*secp256k1_schnorr_msghash)(unsigned char *h32, const unsigned cha
 static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context* ctx, unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar *nonce, const secp256k1_ge *pubnonce, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
 static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, const secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
 static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
-static int secp256k1_schnorr_sig_combine(unsigned char *sig64, int n, const unsigned char * const *sig64ins);
+static int secp256k1_schnorr_sig_combine(unsigned char *sig64, size_t n, const unsigned char * const *sig64ins);
 
 #endif

--- a/src/modules/schnorr/schnorr.h
+++ b/src/modules/schnorr/schnorr.h
@@ -12,9 +12,19 @@
 
 typedef void (*secp256k1_schnorr_msghash)(unsigned char *h32, const unsigned char *r32, const unsigned char *msg32);
 
-static int secp256k1_schnorr_sig_sign(const secp256k1_ecmult_gen_context* ctx, unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar *nonce, const secp256k1_ge *pubnonce, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+/** Compute the private and public nonce to use in signing, based on a 32-byte array and the sum of others' public nonces. */
+static int secp256k1_schnorr_nonces_set_b32(const secp256k1_ecmult_gen_context* ctx, secp256k1_scalar* nonce_mine, secp256k1_ge* pubnonce_all, const unsigned char *b32, const secp256k1_ge* pubnonce_others);
+
+/** Compute a Schnorr signature given a private key, your own private nonce, and the sum of everyone's public nonces. */
+static int secp256k1_schnorr_sig_sign(unsigned char *sig64, const secp256k1_scalar *key, const secp256k1_scalar* priv_mine, const secp256k1_ge* pub_all, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+
+/** Verify a Schnorr signature. */
 static int secp256k1_schnorr_sig_verify(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, const secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+
+/** Recover the public key of the signer of a Schnorr signature, assuming it is valid. */
 static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, const unsigned char *sig64, secp256k1_ge *pubkey, secp256k1_schnorr_msghash hash, const unsigned char *msg32);
+
+/** Combine several partial stage 2 Schnorr signatures. */
 static int secp256k1_schnorr_sig_combine(unsigned char *sig64, size_t n, const unsigned char * const *sig64ins);
 
 #endif

--- a/src/modules/schnorr/schnorr.md
+++ b/src/modules/schnorr/schnorr.md
@@ -1,0 +1,140 @@
+Schnorr-SHA256 module
+=====================
+
+This module implements a custom Schnorr-based signature scheme.
+
+Features:
+* Fixed size 64-byte signatures
+* Public key recovery without additional information
+* Batch validation (not yet implemented)
+* Multiparty signing with 2 rounds of communication but no setup
+
+### Signature format
+
+Signatures and stage 2 partial multisignatures:
+* 32-byte big endian unsigned integer in the range [0..p-1], R.x.
+* 32-byte big endian unsigned integer in the range [0..order-1], s.
+
+Stage 1 partial multisignatures:
+* 32-byte big endian unsigned integer in the range [0..p-1], R(i).x.
+* 64-byte normal signature.
+
+### Algorithm description
+
+##### Signing
+
+Inputs:
+* 32-byte message m
+* 32-byte scalar private key x (!=0)
+* 32-byte scalar private nonce k (!=0)
+
+Steps:
+* Compute public nonce R = k * G.
+* If R.y is odd, negate k and R.
+* Compute scalar h = SHA256(R.x || m). If h == 0 or h >= order, fail.
+* Compute scalar s = k - h * x.
+* The signature is (R.x, s).
+
+##### Verification (method 1)
+
+Inputs:
+* 32-byte message m
+* public key point Q
+* signature pair (32-byte r, scalar s)
+
+Steps:
+* Signature is invalid if s >= order.
+* Signature is invalid if r >= p.
+* Compute scalar h = Hash(r || m). Signature is invalid if h == 0 or h >= order.
+* Compute point R = h * Q + s * G. Signature is invalid if R is infinity or R's
+  y coordinate is odd.
+* Signature is valid if the serialization of R's x coordinate equals r.
+
+This method is faster for single signature verification.
+
+##### Verification (method 2)
+
+Inputs:
+* 32-byte message m
+* public key point Q
+* signature pair (32-byte r, scalar s)
+
+Steps:
+* Signature is invalid if s >= order.
+* Signature is invalid if r >= p.
+* Compute scalar h = Hash(r || m). Signature is invalid if h == 0 or h >= order.
+* Decompress x coordinate r into point R, with odd y coordinate. Fail if R is
+  not on the curve.
+* Signature is valid if R + h * Q + s * G == 0.
+
+This method is needed for batch verification and public key recovery.
+
+##### Multisigning stage 1
+
+Inputs:
+* 32-byte message m
+* 32-byte scalar private key x(i) (!=0)
+* 32-byte scalar private nonce k(i) (!=0)
+
+Steps:
+* Compute public nonce R(i) = k(i) * G.
+* If R.y is odd, negate k(i) and R(i).
+* Sign the message SHA256(R(i).x || m) with private key x(i), resulting in
+  sig(i).
+* The partial signature is (R(i).x, sig(i)).
+
+##### Multisigning stage 2
+
+Inputs:
+* 32-byte message m
+* 32-byte scalar private key x(i) (!=0)
+* 32-byte scalar private nonce k(i) (!=0)
+* Partial stage 1 signatures (R(j).x, sig(j)) from all other cosigners, for all
+  j != i
+* Public keys from all other cosigners, Q(j), for all j != i
+
+Steps:
+* Compute (or reuse from stage 1) public nonce R(i) = k(i) * G.
+* If R(i).y is odd, negate k(i) and R(i).
+* Verify for all j whether sig(j) is a valid signature for message
+  SHA256(R(j).x || m). If not, fail.
+* Convert each R(j).x coordinate into an R(j) point.
+* Compute the sum Rall of all the R(j) points, including your own R(i).
+* If Rall.y is odd, negate k(i) and Rall.
+* Compute scalar h = SHA256(Rall.x || m). If h == 0 or h >= order, fail.
+* Compute scalar s(i) = k(i) - h * x.
+* The partial stage 2 signature is (Rall.x, s(i)).
+
+##### Multisigning stage 3
+
+Inputs:
+* Partial stage 2 signatures (Rall.x, s(j)) from all other cosigners, for all j
+
+Steps:
+* Check whether all Rall.x values in each of the stage 2 signature are
+  identical. If not, fail.
+* Compute the sum sall of all s(i) values.
+* The full combined signature is (Rall.x, s(i)).
+
+### Design choices
+
+##### Rationale for verifying R's Y coordinate:
+
+In order to support batch verification and public key recovery, the full R point
+must be known to verifiers, rather than just its x coordinate. In order to not
+risk being more strict in batch verification than normal verification,
+verifiers must be required to reject signatures with incorrect y coordinate.
+This is only possible by including either:
+* a field inverse to compute the affine coordinates of R
+* a field square root to decompres the x coordinate into a full point R
+
+Both are relatively slow operations, However, batch validation offers
+potentially much higher benefits than this cost.
+
+##### Rationale for having an implicit Y coordinate oddness
+
+If we commit to having the full R point known to verifiers, there are two
+mechanisms. Either include its oddness in the signature, or give it an implicit
+fixed value. As the R y coordinate can be flipped by a simple negation of the
+nonce, we choose the latter, as it comes with nearly zero impact on signing or
+verification performance, and saves a byte in the signature.

--- a/src/modules/schnorr/schnorr_impl.h
+++ b/src/modules/schnorr/schnorr_impl.h
@@ -178,19 +178,19 @@ static int secp256k1_schnorr_sig_recover(const secp256k1_ecmult_context* ctx, co
     return 1;
 }
 
-static int secp256k1_schnorr_sig_combine(unsigned char *sig64, int n, const unsigned char * const *sig64ins) {
+static int secp256k1_schnorr_sig_combine(unsigned char *sig64, size_t n, const unsigned char * const *sig64ins) {
     secp256k1_scalar s = SECP256K1_SCALAR_CONST(0, 0, 0, 0, 0, 0, 0, 0);
-    int i;
+    size_t i;
     for (i = 0; i < n; i++) {
         secp256k1_scalar si;
         int overflow;
         secp256k1_scalar_set_b32(&si, sig64ins[i] + 32, &overflow);
         if (overflow) {
-            return -1;
+            return 0;
         }
         if (i) {
             if (memcmp(sig64ins[i - 1], sig64ins[i], 32) != 0) {
-                return -1;
+                return 0;
             }
         }
         secp256k1_scalar_add(&s, &s, &si);

--- a/src/modules/schnorr/tests_impl.h
+++ b/src/modules/schnorr/tests_impl.h
@@ -52,7 +52,7 @@ void test_schnorr_sign_verify(void) {
     unsigned char sig64[3][64];
     secp256k1_gej pubkeyj[3];
     secp256k1_ge pubkey[3];
-    secp256k1_scalar nonce[3], key[3];
+    secp256k1_scalar key[3];
     int i = 0;
     int k;
 
@@ -62,8 +62,11 @@ void test_schnorr_sign_verify(void) {
         random_scalar_order_test(&key[k]);
 
         do {
-            random_scalar_order_test(&nonce[k]);
-            if (secp256k1_schnorr_sig_sign(&ctx->ecmult_gen_ctx, sig64[k], &key[k], &nonce[k], NULL, &test_schnorr_hash, msg32)) {
+            unsigned char nonce32[32];
+            secp256k1_ge pubnonce;
+            secp256k1_scalar privnonce;
+            secp256k1_rand256_test(nonce32);
+            if (secp256k1_schnorr_nonces_set_b32(&ctx->ecmult_gen_ctx, &privnonce, &pubnonce, nonce32, NULL) && secp256k1_schnorr_sig_sign(sig64[k], &key[k], &privnonce, &pubnonce, &test_schnorr_hash, msg32)) {
                 break;
             }
         } while(1);

--- a/src/modules/schnorr/tests_impl.h
+++ b/src/modules/schnorr/tests_impl.h
@@ -82,63 +82,74 @@ void test_schnorr_sign_verify(void) {
     }
 }
 
-void test_schnorr_threshold(void) {
+void test_schnorr_multisign(void) {
     unsigned char msg[32];
     unsigned char sec[5][32];
     secp256k1_pubkey pub[5];
-    unsigned char nonce[5][32];
-    secp256k1_pubkey pubnonce[5];
-    unsigned char sig[5][64];
-    const unsigned char* sigs[5];
+    unsigned char stage1[5][96];
+    unsigned char stage2[5][64];
     unsigned char allsig[64];
-    const secp256k1_pubkey* pubs[5];
+    unsigned char allsig1[64];
+    const secp256k1_pubkey *allpubs[5];
+    const unsigned char *allstage2s[5];
     secp256k1_pubkey allpub;
     int n, i;
     int damage;
     int ret = 0;
 
-    damage = (secp256k1_rand32() % 2) ? (1 + (secp256k1_rand32() % 4)) : 0;
+    n = 1 + (secp256k1_rand32() % 5);
+    if (n == 1) {
+        damage = (secp256k1_rand32() % 2) ? (2 + (secp256k1_rand32() % 3)) : 0;
+    } else {
+        damage = (secp256k1_rand32() % 2) ? (1 + (secp256k1_rand32() % 4)) : 0;
+    }
     secp256k1_rand256_test(msg);
-    n = 2 + (secp256k1_rand32() % 4);
     for (i = 0; i < n; i++) {
         do {
             secp256k1_rand256_test(sec[i]);
         } while (!secp256k1_ec_seckey_verify(ctx, sec[i]));
         CHECK(secp256k1_ec_pubkey_create(ctx, &pub[i], sec[i]));
-        CHECK(secp256k1_schnorr_generate_nonce_pair(ctx, &pubnonce[i], nonce[i], msg, sec[i], NULL, NULL));
-        pubs[i] = &pub[i];
+        CHECK(secp256k1_schnorr_multisign_stage1(ctx, stage1[i], msg, sec[i], NULL, NULL));
+        CHECK(secp256k1_schnorr_sign(ctx, allsig1, msg, sec[i], NULL, NULL));
+        CHECK(memcmp(stage1[i], allsig1, 32) == 0);
+        allpubs[i] = &pub[i];
     }
     if (damage == 1) {
-        nonce[secp256k1_rand32() % n][secp256k1_rand32() % 32] ^= 1 + (secp256k1_rand32() % 255);
+        stage1[secp256k1_rand32() % (n - 1)][secp256k1_rand32() % 97] ^= 1 + (secp256k1_rand32() % 255);
     } else if (damage == 2) {
         sec[secp256k1_rand32() % n][secp256k1_rand32() % 32] ^= 1 + (secp256k1_rand32() % 255);
     }
     for (i = 0; i < n; i++) {
-        secp256k1_pubkey allpubnonce;
-        const secp256k1_pubkey *pubnonces[4];
+        const unsigned char *stage1s[4];
+        const secp256k1_pubkey *pubs[4];
         int j;
         for (j = 0; j < i; j++) {
-            pubnonces[j] = &pubnonce[j];
+            stage1s[j] = stage1[j];
+            pubs[j] = &pub[j];
         }
         for (j = i + 1; j < n; j++) {
-            pubnonces[j - 1] = &pubnonce[j];
+            stage1s[j - 1] = stage1[j];
+            pubs[j - 1] = &pub[j];
         }
-        CHECK(secp256k1_ec_pubkey_combine(ctx, &allpubnonce, pubnonces, n - 1));
-        ret |= (secp256k1_schnorr_partial_sign(ctx, sig[i], msg, sec[i], &allpubnonce, nonce[i]) != 1) * 1;
-        sigs[i] = sig[i];
+        ret |= (secp256k1_schnorr_multisign_stage2(ctx, stage2[i], stage1s, n - 1, msg, pubs, sec[i], NULL, NULL) != 1) * 1;
+        allstage2s[i] = stage2[i];
     }
     if (damage == 3) {
-        sig[secp256k1_rand32() % n][secp256k1_rand32() % 64] ^= 1 + (secp256k1_rand32() % 255);
+        stage2[secp256k1_rand32() % n][secp256k1_rand32() % 64] ^= 1 + (secp256k1_rand32() % 255);
     }
-    ret |= (secp256k1_ec_pubkey_combine(ctx, &allpub, pubs, n) != 1) * 2;
+    ret |= (secp256k1_ec_pubkey_combine(ctx, &allpub, allpubs, n) != 1) * 2;
     if ((ret & 1) == 0) {
-        ret |= (secp256k1_schnorr_partial_combine(ctx, allsig, sigs, n) != 1) * 4;
+        ret |= (secp256k1_schnorr_multisign_combine(ctx, allsig, allstage2s, n) != 1) * 4;
     }
     if (damage == 4) {
-        allsig[secp256k1_rand32() % 32] ^= 1 + (secp256k1_rand32() % 255);
+        allsig[secp256k1_rand32() % 64] ^= 1 + (secp256k1_rand32() % 255);
     }
     if ((ret & 7) == 0) {
         ret |= (secp256k1_schnorr_verify(ctx, allsig, msg, &allpub) != 1) * 8;
+    }
+    if (n == 1 && (ret == 0)) {
+        ret |= (secp256k1_schnorr_sign(ctx, allsig1, msg, sec[0], NULL, NULL) != 1) * 16;
+        ret |= (memcmp(allsig1, allsig, 64) != 0) * 32;
     }
     CHECK((ret == 0) == (damage == 0));
 }
@@ -168,7 +179,7 @@ void run_schnorr_tests(void) {
          test_schnorr_recovery();
     }
     for (i = 0; i < 10 * count; i++) {
-         test_schnorr_threshold();
+         test_schnorr_multisign();
     }
 }
 

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -476,8 +476,8 @@ int secp256k1_context_randomize(secp256k1_context* ctx, const unsigned char *see
     return 1;
 }
 
-int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, const secp256k1_pubkey * const *pubnonces, int n) {
-    int i;
+int secp256k1_ec_pubkey_combine(const secp256k1_context* ctx, secp256k1_pubkey *pubnonce, const secp256k1_pubkey * const *pubnonces, size_t n) {
+    size_t i;
     secp256k1_gej Qj;
     secp256k1_ge Q;
 


### PR DESCRIPTION
Instead of asking users to manually generate nonces separately and combine them, there are now specific stage1, stage2 and combine functions which generate 1) signed nonces 2) partial signatures 3) full signatures. This is easier, faster, and more secure (by baking signing of nonces into the API).