### PR TITLE
Moves all test-only code into tests and re-enables -Wunused-function.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,27 +62,6 @@ case $host_os in
    ;;
 esac
 
-CFLAGS="$CFLAGS -W"
-
-warn_CFLAGS="-std=c89 -pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-unused-function -Wno-long-long -Wno-overlength-strings"
-saved_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS $warn_CFLAGS"
-AC_MSG_CHECKING([if ${CC} supports ${warn_CFLAGS}])
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
-    [ AC_MSG_RESULT([yes]) ],
-    [ AC_MSG_RESULT([no])
-      CFLAGS="$saved_CFLAGS"
-    ])
-
-saved_CFLAGS="$CFLAGS"
-CFLAGS="$CFLAGS -fvisibility=hidden"
-AC_MSG_CHECKING([if ${CC} supports -fvisibility=hidden])
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
-    [ AC_MSG_RESULT([yes]) ],
-    [ AC_MSG_RESULT([no])
-      CFLAGS="$saved_CFLAGS"
-    ])
-
 AC_ARG_ENABLE(benchmark,
     AS_HELP_STRING([--enable-benchmark],[compile benchmark (default is no)]),
     [use_benchmark=$enableval],
@@ -129,6 +108,42 @@ AC_ARG_WITH([scalar], [AS_HELP_STRING([--with-scalar=64bit|32bit|auto],
 
 AC_ARG_WITH([asm], [AS_HELP_STRING([--with-asm=x86_64|no|auto]
 [Specify assembly optimizations to use. Default is auto])],[req_asm=$withval], [req_asm=auto])
+
+CFLAGS="$CFLAGS -W"
+
+dnl There are a few intentionally unused functions if you are not building with all the bells and whistles.
+warn_unused_CFLAGS="-Wno-unused-function"
+dnl if all modules are enabled and no static precomp, don't add -Wno-unused-function
+if test x"$use_ecmult_static_precomputation" = x"no"; then
+ if test x"$enable_module_ecdh" = x"yes"; then
+  if test x"$enable_module_schnorr" = x"yes"; then
+   if test x"$enable_module_recovery" = x"yes"; then
+    warn_unused_CFLAGS=""
+   fi
+  fi
+ fi
+fi
+
+dnl -Wno-overlength-strings is needed by some versions of clang due to spurious warnings on assembly code.
+warn_CFLAGS="-std=c89 -pedantic -Wall -Wextra -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -Wno-long-long -Wno-overlength-strings $warn_unused_CFLAGS"
+
+saved_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS $warn_CFLAGS"
+AC_MSG_CHECKING([if ${CC} supports ${warn_CFLAGS}])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+    [ AC_MSG_RESULT([yes]) ],
+    [ AC_MSG_RESULT([no])
+      CFLAGS="$saved_CFLAGS"
+    ])
+
+saved_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -fvisibility=hidden"
+AC_MSG_CHECKING([if ${CC} supports -fvisibility=hidden])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[char foo;]])],
+    [ AC_MSG_RESULT([yes]) ],
+    [ AC_MSG_RESULT([no])
+      CFLAGS="$saved_CFLAGS"
+    ])
 
 AC_CHECK_TYPES([__int128])
 

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -17,6 +17,5 @@ static int secp256k1_ecdsa_sig_parse(secp256k1_scalar *r, secp256k1_scalar *s, c
 static int secp256k1_ecdsa_sig_serialize(unsigned char *sig, size_t *size, const secp256k1_scalar *r, const secp256k1_scalar *s);
 static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context *ctx, const secp256k1_scalar* r, const secp256k1_scalar* s, const secp256k1_ge *pubkey, const secp256k1_scalar *message);
 static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar* r, secp256k1_scalar* s, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid);
-static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context *ctx, const secp256k1_scalar* r, const secp256k1_scalar* s, secp256k1_ge *pubkey, const secp256k1_scalar *message, int recid);
 
 #endif

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -187,39 +187,6 @@ static int secp256k1_ecdsa_sig_verify(const secp256k1_ecmult_context *ctx, const
     return 0;
 }
 
-static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context *ctx, const secp256k1_scalar *sigr, const secp256k1_scalar* sigs, secp256k1_ge *pubkey, const secp256k1_scalar *message, int recid) {
-    unsigned char brx[32];
-    secp256k1_fe fx;
-    secp256k1_ge x;
-    secp256k1_gej xj;
-    secp256k1_scalar rn, u1, u2;
-    secp256k1_gej qj;
-
-    if (secp256k1_scalar_is_zero(sigr) || secp256k1_scalar_is_zero(sigs)) {
-        return 0;
-    }
-
-    secp256k1_scalar_get_b32(brx, sigr);
-    VERIFY_CHECK(secp256k1_fe_set_b32(&fx, brx)); /* brx comes from a scalar, so is less than the order; certainly less than p */
-    if (recid & 2) {
-        if (secp256k1_fe_cmp_var(&fx, &secp256k1_ecdsa_const_p_minus_order) >= 0) {
-            return 0;
-        }
-        secp256k1_fe_add(&fx, &secp256k1_ecdsa_const_order_as_fe);
-    }
-    if (!secp256k1_ge_set_xo_var(&x, &fx, recid & 1)) {
-        return 0;
-    }
-    secp256k1_gej_set_ge(&xj, &x);
-    secp256k1_scalar_inverse_var(&rn, sigr);
-    secp256k1_scalar_mul(&u1, &rn, message);
-    secp256k1_scalar_negate(&u1, &u1);
-    secp256k1_scalar_mul(&u2, &rn, sigs);
-    secp256k1_ecmult(ctx, &qj, &xj, &u2, &u1);
-    secp256k1_ge_set_gej_var(pubkey, &qj);
-    return !secp256k1_gej_is_infinity(&qj);
-}
-
 static int secp256k1_ecdsa_sig_sign(const secp256k1_ecmult_gen_context *ctx, secp256k1_scalar *sigr, secp256k1_scalar *sigs, const secp256k1_scalar *seckey, const secp256k1_scalar *message, const secp256k1_scalar *nonce, int *recid) {
     unsigned char b[32];
     secp256k1_gej rp;

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -40,10 +40,6 @@ static void secp256k1_fe_verify(const secp256k1_fe *a) {
     }
     VERIFY_CHECK(r == 1);
 }
-#else
-static void secp256k1_fe_verify(const secp256k1_fe *a) {
-    (void)a;
-}
 #endif
 
 static void secp256k1_fe_normalize(secp256k1_fe *r) {

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -50,10 +50,6 @@ static void secp256k1_fe_verify(const secp256k1_fe *a) {
     }
     VERIFY_CHECK(r == 1);
 }
-#else
-static void secp256k1_fe_verify(const secp256k1_fe *a) {
-    (void)a;
-}
 #endif
 
 static void secp256k1_fe_normalize(secp256k1_fe *r) {

--- a/src/group.h
+++ b/src/group.h
@@ -58,6 +58,9 @@ static void secp256k1_ge_neg(secp256k1_ge *r, const secp256k1_ge *a);
 /** Set a group element equal to another which is given in jacobian coordinates */
 static void secp256k1_ge_set_gej(secp256k1_ge *r, secp256k1_gej *a);
 
+/** Set a group element equal to another which is given in jacobian coordinates */
+static void secp256k1_ge_set_gej_var(secp256k1_ge *r, secp256k1_gej *a);
+
 /** Set a batch of group elements equal to the inputs given in jacobian coordinates */
 static void secp256k1_ge_set_all_gej_var(size_t len, secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_callback *cb);
 

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -211,26 +211,6 @@ static int secp256k1_gej_is_infinity(const secp256k1_gej *a) {
     return a->infinity;
 }
 
-static int secp256k1_gej_is_valid_var(const secp256k1_gej *a) {
-    secp256k1_fe y2, x3, z2, z6;
-    if (a->infinity) {
-        return 0;
-    }
-    /** y^2 = x^3 + 7
-     *  (Y/Z^3)^2 = (X/Z^2)^3 + 7
-     *  Y^2 / Z^6 = X^3 / Z^6 + 7
-     *  Y^2 = X^3 + 7*Z^6
-     */
-    secp256k1_fe_sqr(&y2, &a->y);
-    secp256k1_fe_sqr(&x3, &a->x); secp256k1_fe_mul(&x3, &x3, &a->x);
-    secp256k1_fe_sqr(&z2, &a->z);
-    secp256k1_fe_sqr(&z6, &z2); secp256k1_fe_mul(&z6, &z6, &z2);
-    secp256k1_fe_mul_int(&z6, 7);
-    secp256k1_fe_add(&x3, &z6);
-    secp256k1_fe_normalize_weak(&x3);
-    return secp256k1_fe_equal_var(&y2, &x3);
-}
-
 static int secp256k1_ge_is_valid_var(const secp256k1_ge *a) {
     secp256k1_fe y2, x3, c;
     if (a->infinity) {

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -130,6 +130,39 @@ int secp256k1_ecdsa_sign_recoverable(const secp256k1_context* ctx, secp256k1_ecd
     return ret;
 }
 
+static int secp256k1_ecdsa_sig_recover(const secp256k1_ecmult_context *ctx, const secp256k1_scalar *sigr, const secp256k1_scalar* sigs, secp256k1_ge *pubkey, const secp256k1_scalar *message, int recid) {
+    unsigned char brx[32];
+    secp256k1_fe fx;
+    secp256k1_ge x;
+    secp256k1_gej xj;
+    secp256k1_scalar rn, u1, u2;
+    secp256k1_gej qj;
+
+    if (secp256k1_scalar_is_zero(sigr) || secp256k1_scalar_is_zero(sigs)) {
+        return 0;
+    }
+
+    secp256k1_scalar_get_b32(brx, sigr);
+    VERIFY_CHECK(secp256k1_fe_set_b32(&fx, brx)); /* brx comes from a scalar, so is less than the order; certainly less than p */
+    if (recid & 2) {
+        if (secp256k1_fe_cmp_var(&fx, &secp256k1_ecdsa_const_p_minus_order) >= 0) {
+            return 0;
+        }
+        secp256k1_fe_add(&fx, &secp256k1_ecdsa_const_order_as_fe);
+    }
+    if (!secp256k1_ge_set_xo_var(&x, &fx, recid & 1)) {
+        return 0;
+    }
+    secp256k1_gej_set_ge(&xj, &x);
+    secp256k1_scalar_inverse_var(&rn, sigr);
+    secp256k1_scalar_mul(&u1, &rn, message);
+    secp256k1_scalar_negate(&u1, &u1);
+    secp256k1_scalar_mul(&u2, &rn, sigs);
+    secp256k1_ecmult(ctx, &qj, &xj, &u2, &u1);
+    secp256k1_ge_set_gej_var(pubkey, &qj);
+    return !secp256k1_gej_is_infinity(&qj);
+}
+
 int secp256k1_ecdsa_recover(const secp256k1_context* ctx, secp256k1_pubkey *pubkey, const secp256k1_ecdsa_recoverable_signature *signature, const unsigned char *msg32) {
     secp256k1_ge q;
     secp256k1_scalar r, s;

--- a/src/num.h
+++ b/src/num.h
@@ -19,8 +19,6 @@
 #error "Please select num implementation"
 #endif
 
-/** Copy a number. */
-static void secp256k1_num_copy(secp256k1_num *r, const secp256k1_num *a);
 
 /** Convert a number's absolute value to a binary big-endian string.
  *  There must be enough place. */
@@ -31,37 +29,6 @@ static void secp256k1_num_set_bin(secp256k1_num *r, const unsigned char *a, unsi
 
 /** Compute a modular inverse. The input must be less than the modulus. */
 static void secp256k1_num_mod_inverse(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *m);
-
-/** Compare the absolute value of two numbers. */
-static int secp256k1_num_cmp(const secp256k1_num *a, const secp256k1_num *b);
-
-/** Test whether two number are equal (including sign). */
-static int secp256k1_num_eq(const secp256k1_num *a, const secp256k1_num *b);
-
-/** Add two (signed) numbers. */
-static void secp256k1_num_add(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b);
-
-/** Subtract two (signed) numbers. */
-static void secp256k1_num_sub(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b);
-
-/** Multiply two (signed) numbers. */
-static void secp256k1_num_mul(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b);
-
-/** Replace a number by its remainder modulo m. M's sign is ignored. The result is a number between 0 and m-1,
-    even if r was negative. */
-static void secp256k1_num_mod(secp256k1_num *r, const secp256k1_num *m);
-
-/** Right-shift the passed number by bits bits. */
-static void secp256k1_num_shift(secp256k1_num *r, int bits);
-
-/** Check whether a number is zero. */
-static int secp256k1_num_is_zero(const secp256k1_num *a);
-
-/** Check whether a number is strictly negative. */
-static int secp256k1_num_is_neg(const secp256k1_num *a);
-
-/** Change a number's sign. */
-static void secp256k1_num_negate(secp256k1_num *r);
 
 #endif
 

--- a/src/num_gmp_impl.h
+++ b/src/num_gmp_impl.h
@@ -22,10 +22,6 @@ static void secp256k1_num_sanity(const secp256k1_num *a) {
 #define secp256k1_num_sanity(a) do { } while(0)
 #endif
 
-static void secp256k1_num_copy(secp256k1_num *r, const secp256k1_num *a) {
-    *r = *a;
-}
-
 static void secp256k1_num_get_bin(unsigned char *r, unsigned int rlen, const secp256k1_num *a) {
     unsigned char tmp[65];
     int len = 0;
@@ -56,44 +52,6 @@ static void secp256k1_num_set_bin(secp256k1_num *r, const unsigned char *a, unsi
     r->neg = 0;
     while (r->limbs > 1 && r->data[r->limbs-1]==0) {
         r->limbs--;
-    }
-}
-
-static void secp256k1_num_add_abs(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
-    mp_limb_t c = mpn_add(r->data, a->data, a->limbs, b->data, b->limbs);
-    r->limbs = a->limbs;
-    if (c != 0) {
-        VERIFY_CHECK(r->limbs < 2*NUM_LIMBS);
-        r->data[r->limbs++] = c;
-    }
-}
-
-static void secp256k1_num_sub_abs(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
-    mp_limb_t c = mpn_sub(r->data, a->data, a->limbs, b->data, b->limbs);
-    VERIFY_CHECK(c == 0);
-    r->limbs = a->limbs;
-    while (r->limbs > 1 && r->data[r->limbs-1]==0) {
-        r->limbs--;
-    }
-}
-
-static void secp256k1_num_mod(secp256k1_num *r, const secp256k1_num *m) {
-    secp256k1_num_sanity(r);
-    secp256k1_num_sanity(m);
-
-    if (r->limbs >= m->limbs) {
-        mp_limb_t t[2*NUM_LIMBS];
-        mpn_tdiv_qr(t, r->data, 0, r->data, r->limbs, m->data, m->limbs);
-        memset(t, 0, sizeof(t));
-        r->limbs = m->limbs;
-        while (r->limbs > 1 && r->data[r->limbs-1]==0) {
-            r->limbs--;
-        }
-    }
-
-    if (r->neg && (r->limbs > 1 || r->data[0] != 0)) {
-        secp256k1_num_sub_abs(r, m, r);
-        r->neg = 0;
     }
 }
 
@@ -140,121 +98,6 @@ static void secp256k1_num_mod_inverse(secp256k1_num *r, const secp256k1_num *a, 
     memset(g, 0, sizeof(g));
     memset(u, 0, sizeof(u));
     memset(v, 0, sizeof(v));
-}
-
-static int secp256k1_num_is_zero(const secp256k1_num *a) {
-    return (a->limbs == 1 && a->data[0] == 0);
-}
-
-static int secp256k1_num_is_neg(const secp256k1_num *a) {
-    return (a->limbs > 1 || a->data[0] != 0) && a->neg;
-}
-
-static int secp256k1_num_cmp(const secp256k1_num *a, const secp256k1_num *b) {
-    if (a->limbs > b->limbs) {
-        return 1;
-    }
-    if (a->limbs < b->limbs) {
-        return -1;
-    }
-    return mpn_cmp(a->data, b->data, a->limbs);
-}
-
-static int secp256k1_num_eq(const secp256k1_num *a, const secp256k1_num *b) {
-    if (a->limbs > b->limbs) {
-        return 0;
-    }
-    if (a->limbs < b->limbs) {
-        return 0;
-    }
-    if ((a->neg && !secp256k1_num_is_zero(a)) != (b->neg && !secp256k1_num_is_zero(b))) {
-        return 0;
-    }
-    return mpn_cmp(a->data, b->data, a->limbs) == 0;
-}
-
-static void secp256k1_num_subadd(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b, int bneg) {
-    if (!(b->neg ^ bneg ^ a->neg)) { /* a and b have the same sign */
-        r->neg = a->neg;
-        if (a->limbs >= b->limbs) {
-            secp256k1_num_add_abs(r, a, b);
-        } else {
-            secp256k1_num_add_abs(r, b, a);
-        }
-    } else {
-        if (secp256k1_num_cmp(a, b) > 0) {
-            r->neg = a->neg;
-            secp256k1_num_sub_abs(r, a, b);
-        } else {
-            r->neg = b->neg ^ bneg;
-            secp256k1_num_sub_abs(r, b, a);
-        }
-    }
-}
-
-static void secp256k1_num_add(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
-    secp256k1_num_sanity(a);
-    secp256k1_num_sanity(b);
-    secp256k1_num_subadd(r, a, b, 0);
-}
-
-static void secp256k1_num_sub(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
-    secp256k1_num_sanity(a);
-    secp256k1_num_sanity(b);
-    secp256k1_num_subadd(r, a, b, 1);
-}
-
-static void secp256k1_num_mul(secp256k1_num *r, const secp256k1_num *a, const secp256k1_num *b) {
-    mp_limb_t tmp[2*NUM_LIMBS+1];
-    secp256k1_num_sanity(a);
-    secp256k1_num_sanity(b);
-
-    VERIFY_CHECK(a->limbs + b->limbs <= 2*NUM_LIMBS+1);
-    if ((a->limbs==1 && a->data[0]==0) || (b->limbs==1 && b->data[0]==0)) {
-        r->limbs = 1;
-        r->neg = 0;
-        r->data[0] = 0;
-        return;
-    }
-    if (a->limbs >= b->limbs) {
-        mpn_mul(tmp, a->data, a->limbs, b->data, b->limbs);
-    } else {
-        mpn_mul(tmp, b->data, b->limbs, a->data, a->limbs);
-    }
-    r->limbs = a->limbs + b->limbs;
-    if (r->limbs > 1 && tmp[r->limbs - 1]==0) {
-        r->limbs--;
-    }
-    VERIFY_CHECK(r->limbs <= 2*NUM_LIMBS);
-    mpn_copyi(r->data, tmp, r->limbs);
-    r->neg = a->neg ^ b->neg;
-    memset(tmp, 0, sizeof(tmp));
-}
-
-static void secp256k1_num_shift(secp256k1_num *r, int bits) {
-    if (bits % GMP_NUMB_BITS) {
-        /* Shift within limbs. */
-        mpn_rshift(r->data, r->data, r->limbs, bits % GMP_NUMB_BITS);
-    }
-    if (bits >= GMP_NUMB_BITS) {
-        int i;
-        /* Shift full limbs. */
-        for (i = 0; i < r->limbs; i++) {
-            int index = i + (bits / GMP_NUMB_BITS);
-            if (index < r->limbs && index < 2*NUM_LIMBS) {
-                r->data[i] = r->data[index];
-            } else {
-                r->data[i] = 0;
-            }
-        }
-    }
-    while (r->limbs>1 && r->data[r->limbs-1]==0) {
-        r->limbs--;
-    }
-}
-
-static void secp256k1_num_negate(secp256k1_num *r) {
-    r->neg ^= 1;
 }
 
 #endif

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -81,9 +81,6 @@ static int secp256k1_scalar_is_high(const secp256k1_scalar *a);
 static int secp256k1_scalar_cond_negate(secp256k1_scalar *a, int flag);
 
 #ifndef USE_NUM_NONE
-/** Convert a scalar to a number. */
-static void secp256k1_scalar_get_num(secp256k1_num *r, const secp256k1_scalar *a);
-
 /** Get the order of the group as a number. */
 static void secp256k1_scalar_order_get_num(secp256k1_num *r);
 #endif

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -25,12 +25,6 @@
 #endif
 
 #ifndef USE_NUM_NONE
-static void secp256k1_scalar_get_num(secp256k1_num *r, const secp256k1_scalar *a) {
-    unsigned char c[32];
-    secp256k1_scalar_get_b32(c, a);
-    secp256k1_num_set_bin(r, c, 32);
-}
-
 /** secp256k1 curve order, see secp256k1_ecdsa_const_order_as_fe in ecdsa_impl.h */
 static void secp256k1_scalar_order_get_num(secp256k1_num *r) {
     static const unsigned char order[32] = {


### PR DESCRIPTION
This moves a large amount of num_impl code into tests.c because we only
 ever use it in tests anymore.  Likewise for secp256k1_gej_is_valid_var.

The -Wunused-function is only enabled when all modules are turned on and
 when static precomp is off.  This avoids warnings for the few parts of
 the base library which are only used by modules (or pre-computation).

[Note, the description of this PR has changed significantly since it was opened, because the PR was narrowed to only being unused clean in an all-modules build.]