### PR TITLE
[API BREAK] Make flags more explicit, add runtime checks.

### DIFF
--- a/include/secp256k1.h
+++ b/include/secp256k1.h
@@ -148,12 +148,21 @@ typedef int (*secp256k1_nonce_function)(
 # endif
 
 /** Flags to pass to secp256k1_context_create. */
-# define SECP256K1_CONTEXT_VERIFY (1 << 0)
-# define SECP256K1_CONTEXT_SIGN   (1 << 1)
+# define SECP256K1_CONTEXT_VERIFY (SECP256K1_CONTEXT_VERIFY_BIT|SECP256K1_CONTEXT_CHECK_BIT)
+# define SECP256K1_CONTEXT_SIGN   (SECP256K1_CONTEXT_SIGN_BIT|SECP256K1_CONTEXT_CHECK_BIT)
+# define SECP256K1_CONTEXT_NONE   (SECP256K1_CONTEXT_CHECK_BIT)
 
+#  define SECP256K1_CONTEXT_VERIFY_BIT     (1 << 2)    
+#  define SECP256K1_CONTEXT_SIGN_BIT       (2 << 2)    
+#  define SECP256K1_CONTEXT_CHECK_BIT      (1)
+       
 /** Flag to pass to secp256k1_ec_pubkey_serialize and secp256k1_ec_privkey_export. */
-# define SECP256K1_EC_COMPRESSED  (1 << 0)
+# define SECP256K1_EC_COMPRESSED  (SECP256K1_EC_COMPRESSED_BIT|SECP256K1_EC_CHECK_BIT)
+# define SECP256K1_EC_UNCOMPRESSED  (SECP256K1_EC_CHECK_BIT)
 
+#  define SECP256K1_EC_COMPRESSED_BIT     (1 << 2)    
+#  define SECP256K1_EC_CHECK_BIT          (2)    
+        
 /** Create a secp256k1 context object.
  *
  *  Returns: a newly created context object.
@@ -261,7 +270,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_parse(
  *  In:   pubkey:     a pointer to a secp256k1_pubkey containing an initialized
  *                    public key.
  *        flags:      SECP256K1_EC_COMPRESSED if serialization should be in
- *                    compressed format.
+ *                    compressed format, otherwise SECP256K1_EC_UNCOMPRESSED.
  */
 SECP256K1_API int secp256k1_ec_pubkey_serialize(
     const secp256k1_context* ctx,
@@ -415,7 +424,7 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ec_pubkey_create(
  *                    privkey will be stored.
  *  In:  seckey:      pointer to a 32-byte secret key to export.
  *       flags:       SECP256K1_EC_COMPRESSED if the key should be exported in
- *                    compressed format.
+ *                    compressed format, otherwise SECP256K1_EC_UNCOMPRESSED.
  *
  *  This function is purely meant for compatibility with applications that
  *  require BER encoded keys. When working with secp256k1-specific code, the

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -40,7 +40,7 @@ static int secp256k1_eckey_pubkey_serialize(secp256k1_ge *elem, unsigned char *p
     secp256k1_fe_normalize_var(&elem->x);
     secp256k1_fe_normalize_var(&elem->y);
     secp256k1_fe_get_b32(&pub[1], &elem->x);
-    if (flags & SECP256K1_EC_COMPRESSED) {
+    if (flags & SECP256K1_EC_COMPRESSED_BIT) {
         *size = 33;
         pub[0] = 0x02 | (secp256k1_fe_is_odd(&elem->y) ? 0x01 : 0x00);
     } else {
@@ -119,7 +119,7 @@ static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context 
         memcpy(ptr, begin, sizeof(begin)); ptr += sizeof(begin);
         secp256k1_scalar_get_b32(ptr, key); ptr += 32;
         memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
-        if (!secp256k1_eckey_pubkey_serialize(&r, ptr, &pubkeylen, 1)) {
+        if (!secp256k1_eckey_pubkey_serialize(&r, ptr, &pubkeylen, SECP256K1_EC_COMPRESSED)) {
             return 0;
         }
         ptr += pubkeylen;
@@ -145,7 +145,7 @@ static int secp256k1_eckey_privkey_serialize(const secp256k1_ecmult_gen_context 
         memcpy(ptr, begin, sizeof(begin)); ptr += sizeof(begin);
         secp256k1_scalar_get_b32(ptr, key); ptr += 32;
         memcpy(ptr, middle, sizeof(middle)); ptr += sizeof(middle);
-        if (!secp256k1_eckey_pubkey_serialize(&r, ptr, &pubkeylen, 0)) {
+        if (!secp256k1_eckey_pubkey_serialize(&r, ptr, &pubkeylen, SECP256K1_EC_UNCOMPRESSED)) {
             return 0;
         }
         ptr += pubkeylen;

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -62,13 +62,20 @@ secp256k1_context* secp256k1_context_create(unsigned int flags) {
     ret->illegal_callback = default_illegal_callback;
     ret->error_callback = default_error_callback;
 
+    if (EXPECT(!(flags & SECP256K1_CONTEXT_CHECK_BIT), 0)) {
+            secp256k1_callback_call(&ret->illegal_callback,
+                                    "Invalid flags");
+            free(ret);
+            return NULL;
+    }
+
     secp256k1_ecmult_context_init(&ret->ecmult_ctx);
     secp256k1_ecmult_gen_context_init(&ret->ecmult_gen_ctx);
 
-    if (flags & SECP256K1_CONTEXT_SIGN) {
+    if (flags & SECP256K1_CONTEXT_SIGN_BIT) {
         secp256k1_ecmult_gen_context_build(&ret->ecmult_gen_ctx, &ret->error_callback);
     }
-    if (flags & SECP256K1_CONTEXT_VERIFY) {
+    if (flags & SECP256K1_CONTEXT_VERIFY_BIT) {
         secp256k1_ecmult_context_build(&ret->ecmult_ctx, &ret->error_callback);
     }
 
@@ -159,6 +166,7 @@ int secp256k1_ec_pubkey_serialize(const secp256k1_context* ctx, unsigned char *o
     secp256k1_ge Q;
 
     (void)ctx;
+    ARG_CHECK(flags & SECP256K1_EC_CHECK_BIT);
     return (secp256k1_pubkey_load(ctx, &Q, pubkey) &&
             secp256k1_eckey_pubkey_serialize(&Q, output, outputlen, flags));
 }
@@ -446,6 +454,7 @@ int secp256k1_ec_privkey_export(const secp256k1_context* ctx, unsigned char *pri
     ARG_CHECK(seckey != NULL);
     ARG_CHECK(privkey != NULL);
     ARG_CHECK(privkeylen != NULL);
+    ARG_CHECK(flags & SECP256K1_EC_CHECK_BIT);
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
 
     secp256k1_scalar_set_b32(&key, seckey, NULL);

--- a/src/tests.c
+++ b/src/tests.c
@@ -104,7 +104,7 @@ void random_scalar_order(secp256k1_scalar *num) {
 }
 
 void run_context_tests(void) {
-    secp256k1_context *none = secp256k1_context_create(0);
+    secp256k1_context *none = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
     secp256k1_context *sign = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
     secp256k1_context *vrfy = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
     secp256k1_context *both = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
@@ -1389,9 +1389,9 @@ void test_point_times_order(const secp256k1_gej *point) {
     secp256k1_ge_set_gej(&res3, &res1);
     CHECK(secp256k1_ge_is_infinity(&res3));
     CHECK(secp256k1_ge_is_valid_var(&res3) == 0);
-    CHECK(secp256k1_eckey_pubkey_serialize(&res3, pub, &psize, 0) == 0);
+    CHECK(secp256k1_eckey_pubkey_serialize(&res3, pub, &psize, SECP256K1_EC_UNCOMPRESSED) == 0);
     psize = 65;
-    CHECK(secp256k1_eckey_pubkey_serialize(&res3, pub, &psize, 1) == 0);
+    CHECK(secp256k1_eckey_pubkey_serialize(&res3, pub, &psize, SECP256K1_EC_COMPRESSED) == 0);
     /* check zero/one edge cases */
     secp256k1_ecmult(&ctx->ecmult_ctx, &res1, point, &zero, &zero);
     secp256k1_ge_set_gej(&res3, &res1);
@@ -1869,12 +1869,12 @@ void test_ecdsa_end_to_end(void) {
     CHECK(secp256k1_ec_pubkey_create(ctx, &pubkey, privkey) == 1);
 
     /* Verify exporting and importing public key. */
-    CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_rand32() % 2) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(ctx, pubkeyc, &pubkeyclen, &pubkey, secp256k1_rand32() % 2 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED) == 1);
     memset(&pubkey, 0, sizeof(pubkey));
     CHECK(secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkeyc, pubkeyclen) == 1);
 
     /* Verify private key import and export. */
-    CHECK(secp256k1_ec_privkey_export(ctx, seckey, &seckeylen, privkey, (secp256k1_rand32() % 2) == 1) ? SECP256K1_EC_COMPRESSED : 0);
+    CHECK(secp256k1_ec_privkey_export(ctx, seckey, &seckeylen, privkey, (secp256k1_rand32() % 2) == 1 ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
     CHECK(secp256k1_ec_privkey_import(ctx, privkey2, seckey, seckeylen) == 1);
     CHECK(memcmp(privkey, privkey2, 32) == 0);
 
@@ -1982,7 +1982,7 @@ void test_random_pubkeys(void) {
         size_t size = len;
         firstb = in[0];
         /* If the pubkey can be parsed, it should round-trip... */
-        CHECK(secp256k1_eckey_pubkey_serialize(&elem, out, &size, (len == 33) ? SECP256K1_EC_COMPRESSED : 0));
+        CHECK(secp256k1_eckey_pubkey_serialize(&elem, out, &size, (len == 33) ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
         CHECK(size == len);
         CHECK(memcmp(&in[1], &out[1], len-1) == 0);
         /* ... except for the type of hybrid inputs. */
@@ -1990,7 +1990,7 @@ void test_random_pubkeys(void) {
             CHECK(in[0] == out[0]);
         }
         size = 65;
-        CHECK(secp256k1_eckey_pubkey_serialize(&elem, in, &size, 0));
+        CHECK(secp256k1_eckey_pubkey_serialize(&elem, in, &size, SECP256K1_EC_UNCOMPRESSED));
         CHECK(size == 65);
         CHECK(secp256k1_eckey_pubkey_parse(&elem2, in, size));
         ge_equals_ge(&elem,&elem2);
@@ -2006,7 +2006,7 @@ void test_random_pubkeys(void) {
         }
         if (res) {
             ge_equals_ge(&elem,&elem2);
-            CHECK(secp256k1_eckey_pubkey_serialize(&elem, out, &size, 0));
+            CHECK(secp256k1_eckey_pubkey_serialize(&elem, out, &size, SECP256K1_EC_UNCOMPRESSED));
             CHECK(memcmp(&in[1], &out[1], 64) == 0);
         }
     }
@@ -2157,7 +2157,7 @@ void test_ecdsa_edge_cases(void) {
             0xbf, 0xd2, 0x5e, 0x8c, 0xd0, 0x36, 0x41, 0x41,
         };
         size_t outlen = 300;
-        CHECK(!secp256k1_ec_privkey_export(ctx, privkey, &outlen, seckey, 0));
+        CHECK(!secp256k1_ec_privkey_export(ctx, privkey, &outlen, seckey, SECP256K1_EC_UNCOMPRESSED));
         outlen = 300;
         CHECK(!secp256k1_ec_privkey_export(ctx, privkey, &outlen, seckey, SECP256K1_EC_COMPRESSED));
     }
@@ -2174,7 +2174,7 @@ EC_KEY *get_openssl_key(const secp256k1_scalar *key) {
     const unsigned char* pbegin = privkey;
     int compr = secp256k1_rand32() & 1;
     EC_KEY *ec_key = EC_KEY_new_by_curve_name(NID_secp256k1);
-    CHECK(secp256k1_eckey_privkey_serialize(&ctx->ecmult_gen_ctx, privkey, &privkeylen, key, compr ? SECP256K1_EC_COMPRESSED : 0));
+    CHECK(secp256k1_eckey_privkey_serialize(&ctx->ecmult_gen_ctx, privkey, &privkeylen, key, compr ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED));
     CHECK(d2i_ECPrivateKey(&ec_key, &pbegin, privkeylen));
     CHECK(EC_KEY_check_key(ec_key));
     return ec_key;


### PR DESCRIPTION
Fewer zeroes, plus check bit to make sure it value is valid.

Signed-off-by: Rusty Russell <rusty@rustcorp.com.au>