### PR TITLE
Do not force benchmarks to be statically linked.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,13 +54,10 @@ if USE_BENCHMARK
 noinst_PROGRAMS += bench_verify bench_sign bench_internal
 bench_verify_SOURCES = src/bench_verify.c
 bench_verify_LDADD = libsecp256k1.la $(SECP_LIBS)
-bench_verify_LDFLAGS = -static
 bench_sign_SOURCES = src/bench_sign.c
 bench_sign_LDADD = libsecp256k1.la $(SECP_LIBS)
-bench_sign_LDFLAGS = -static
 bench_internal_SOURCES = src/bench_internal.c
 bench_internal_LDADD = $(SECP_LIBS)
-bench_internal_LDFLAGS = -static
 bench_internal_CPPFLAGS = $(SECP_INCLUDES)
 endif
 

--- a/src/modules/ecdh/Makefile.am.include
+++ b/src/modules/ecdh/Makefile.am.include
@@ -5,5 +5,4 @@ if USE_BENCHMARK
 noinst_PROGRAMS += bench_ecdh
 bench_ecdh_SOURCES = src/bench_ecdh.c
 bench_ecdh_LDADD = libsecp256k1.la $(SECP_LIBS)
-bench_ecdh_LDFLAGS = -static
 endif

--- a/src/modules/recovery/Makefile.am.include
+++ b/src/modules/recovery/Makefile.am.include
@@ -5,5 +5,4 @@ if USE_BENCHMARK
 noinst_PROGRAMS += bench_recover
 bench_recover_SOURCES = src/bench_recover.c
 bench_recover_LDADD = libsecp256k1.la $(SECP_LIBS)
-bench_recover_LDFLAGS = -static
 endif

--- a/src/modules/schnorr/Makefile.am.include
+++ b/src/modules/schnorr/Makefile.am.include
@@ -7,5 +7,4 @@ if USE_BENCHMARK
 noinst_PROGRAMS += bench_schnorr_verify
 bench_schnorr_verify_SOURCES = src/bench_schnorr_verify.c
 bench_schnorr_verify_LDADD = libsecp256k1.la $(SECP_LIBS)
-bench_schnorr_verify_LDFLAGS = -static
 endif


### PR DESCRIPTION
Libtool will do the right thing and use whatever is available
 based on --enable-shared/--enable-static.

This also means that some of the things we build actually
 test the dynamic library.