### PR TITLE
ECDH from compressed points with "free" sqrt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bench_inv
 bench_ecdh
+bench_ecdh_opt
 bench_sign
 bench_verify
 bench_schnorr_verify

--- a/include/secp256k1_ecdh.h
+++ b/include/secp256k1_ecdh.h
@@ -24,6 +24,14 @@ SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh(
   const unsigned char *privkey
 ) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(4);
 
+SECP256K1_API SECP256K1_WARN_UNUSED_RESULT int secp256k1_ecdh_opt(
+  const secp256k1_context* ctx,
+  unsigned char *result,
+  const unsigned char *pub,
+  size_t publen,
+  const unsigned char *privkey
+) SECP256K1_ARG_NONNULL(1) SECP256K1_ARG_NONNULL(2) SECP256K1_ARG_NONNULL(3) SECP256K1_ARG_NONNULL(5);
+
 # ifdef __cplusplus
 }
 # endif

--- a/src/bench_ecdh_opt.c
+++ b/src/bench_ecdh_opt.c
@@ -13,7 +13,7 @@
 
 typedef struct {
     secp256k1_context *ctx;
-    secp256k1_pubkey pubkey;
+    unsigned char point[33];
     unsigned char scalar[32];
 } bench_ecdh_data;
 
@@ -28,11 +28,12 @@ static void bench_ecdh_setup(void* arg) {
         0xa2, 0xba, 0xd1, 0x84, 0xf8, 0x83, 0xc6, 0x9f
     };
 
-    data->ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
+    data->ctx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
     for (i = 0; i < 32; i++) {
         data->scalar[i] = i + 1;
     }
-    CHECK(secp256k1_ec_pubkey_parse(data->ctx, &data->pubkey, point, sizeof(point)) == 1);
+    CHECK(sizeof(point) == sizeof(data->point));
+    memcpy(data->point, point, sizeof(point));
 }
 
 static void bench_ecdh(void* arg) {
@@ -41,7 +42,7 @@ static void bench_ecdh(void* arg) {
     bench_ecdh_data *data = (bench_ecdh_data*)arg;
 
     for (i = 0; i < 20000; i++) {
-        CHECK(secp256k1_ecdh(data->ctx, res, &data->pubkey, data->scalar) == 1);
+        CHECK(secp256k1_ecdh_opt(data->ctx, res, data->point, sizeof(data->point), data->scalar) == 1);
     }
 }
 

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -191,6 +191,26 @@ void bench_field_sqrt_var(void* arg) {
     }
 }
 
+void bench_field_rsqrt_var(void* arg) {
+    int i;
+    bench_inv_t *data = (bench_inv_t*)arg;
+
+    for (i = 0; i < 20000; i++) {
+        secp256k1_fe_rsqrt_var(&data->fe_x, &data->fe_y, &data->fe_x);
+        secp256k1_fe_add(&data->fe_x, &data->fe_y);
+    }
+}
+
+void bench_field_par_rsqrt_inv_var(void* arg) {
+    int i;
+    bench_inv_t *data = (bench_inv_t*)arg;
+
+    for (i = 0; i < 20000; i++) {
+        secp256k1_fe_par_rsqrt_inv_var(&data->fe_x, &data->fe_y, &data->fe_x, &data->fe_y);
+        secp256k1_fe_add(&data->fe_x, &data->fe_y);
+    }
+}
+
 void bench_group_double_var(void* arg) {
     int i;
     bench_inv_t *data = (bench_inv_t*)arg;
@@ -334,6 +354,8 @@ int main(int argc, char **argv) {
     if (have_flag(argc, argv, "field") || have_flag(argc, argv, "inverse")) run_benchmark("field_inverse", bench_field_inverse, bench_setup, NULL, &data, 10, 20000);
     if (have_flag(argc, argv, "field") || have_flag(argc, argv, "inverse")) run_benchmark("field_inverse_var", bench_field_inverse_var, bench_setup, NULL, &data, 10, 20000);
     if (have_flag(argc, argv, "field") || have_flag(argc, argv, "sqrt")) run_benchmark("field_sqrt_var", bench_field_sqrt_var, bench_setup, NULL, &data, 10, 20000);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "sqrt")) run_benchmark("field_rsqrt_var", bench_field_rsqrt_var, bench_setup, NULL, &data, 10, 20000);
+    if (have_flag(argc, argv, "field") || have_flag(argc, argv, "sqrt") || have_flag(argc, argv, "inverse")) run_benchmark("field_par_rsqrt_inv_var", bench_field_par_rsqrt_inv_var, bench_setup, NULL, &data, 10, 20000);
 
     if (have_flag(argc, argv, "group") || have_flag(argc, argv, "double")) run_benchmark("group_double_var", bench_group_double_var, bench_setup, NULL, &data, 10, 200000);
     if (have_flag(argc, argv, "group") || have_flag(argc, argv, "add")) run_benchmark("group_add_var", bench_group_add_var, bench_setup, NULL, &data, 10, 200000);

--- a/src/field.h
+++ b/src/field.h
@@ -39,13 +39,11 @@ static void secp256k1_fe_normalize_weak(secp256k1_fe *r);
 /** Normalize a field element, without constant-time guarantee. */
 static void secp256k1_fe_normalize_var(secp256k1_fe *r);
 
-/** Verify whether a field element represents zero i.e. would normalize to a zero value. The field
- *  implementation may optionally normalize the input, but this should not be relied upon. */
-static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r);
+/** Verify whether a field element represents zero i.e. would normalize to a zero value. */
+static int secp256k1_fe_normalizes_to_zero(const secp256k1_fe *r);
 
-/** Verify whether a field element represents zero i.e. would normalize to a zero value. The field
- *  implementation may optionally normalize the input, but this should not be relied upon. */
-static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r);
+/** Verify whether a field element represents zero i.e. would normalize to a zero value. */
+static int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r);
 
 /** Set a field element equal to a small integer. Resulting field element is normalized. */
 static void secp256k1_fe_set_int(secp256k1_fe *r, int a);
@@ -88,11 +86,27 @@ static void secp256k1_fe_mul(secp256k1_fe *r, const secp256k1_fe *a, const secp2
 static void secp256k1_fe_sqr(secp256k1_fe *r, const secp256k1_fe *a);
 
 /** If a has a square root, it is computed in r and 1 is returned. If a does not
- *  have a square root, the root of its negation is computed and 0 is returned.
+ *  have a square root, the root of -a is computed and 0 is returned.
  *  The input's magnitude can be at most 8. The output magnitude is 1 (but not
  *  guaranteed to be normalized). The result in r will always be a square
  *  itself. */
 static int secp256k1_fe_sqrt_var(secp256k1_fe *r, const secp256k1_fe *a);
+
+/** If a has a square root, the square root is computed in rs, its reciprocal square root is
+ *  calculated in rr, and 1 is returned. If a does not have a square root, the root (and recip. root)
+ *  of -a are computed and 0 is returned. The input's magnitude can be at most 8. The
+ *  outputs' magnitudes are 1 (but not guaranteed to be normalized). The result in rs will always be
+ *  a square itself. The result in rr will be a square if, and only if, a is a square.
+ */
+static int secp256k1_fe_rsqrt_var(secp256k1_fe *rs, secp256k1_fe *rr, const secp256k1_fe *a);
+
+/** Parallel reciprocal square root and inverse. Sets ri to be the (modular) inverse of b. If a has a
+ *  square root, the reciprocal of its square root is computed in rr and 1 is returned. If a does not
+ *  have a square root, the reciprocal root of -a is computed and 0 is returned. The inputs'
+ *  magnitudes can be at most 8. The outputs' magnitudes are 1 (but not guaranteed to be normalized).
+ *  The result in rr will be a square if, and only if, a is a square.
+ */
+static int secp256k1_fe_par_rsqrt_inv_var(secp256k1_fe *rr,  secp256k1_fe *ri, const secp256k1_fe *a, const secp256k1_fe *b);
 
 /** Sets a field element to be the (modular) inverse of another. Requires the input's magnitude to be
  *  at most 8. The output magnitude is 1 (but not guaranteed to be normalized). */

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -188,7 +188,7 @@ static void secp256k1_fe_normalize_var(secp256k1_fe *r) {
 #endif
 }
 
-static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r) {
+static int secp256k1_fe_normalizes_to_zero(const secp256k1_fe *r) {
     uint32_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4],
              t5 = r->n[5], t6 = r->n[6], t7 = r->n[7], t8 = r->n[8], t9 = r->n[9];
 
@@ -217,7 +217,7 @@ static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r) {
     return (z0 == 0) | (z1 == 0x3FFFFFFUL);
 }
 
-static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r) {
+static int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r) {
     uint32_t t0, t1, t2, t3, t4, t5, t6, t7, t8, t9;
     uint32_t z0, z1;
     uint32_t x;

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -167,7 +167,7 @@ static void secp256k1_fe_normalize_var(secp256k1_fe *r) {
 #endif
 }
 
-static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r) {
+static int secp256k1_fe_normalizes_to_zero(const secp256k1_fe *r) {
     uint64_t t0 = r->n[0], t1 = r->n[1], t2 = r->n[2], t3 = r->n[3], t4 = r->n[4];
 
     /* z0 tracks a possible raw value of 0, z1 tracks a possible raw value of P */
@@ -190,7 +190,7 @@ static int secp256k1_fe_normalizes_to_zero(secp256k1_fe *r) {
     return (z0 == 0) | (z1 == 0xFFFFFFFFFFFFFULL);
 }
 
-static int secp256k1_fe_normalizes_to_zero_var(secp256k1_fe *r) {
+static int secp256k1_fe_normalizes_to_zero_var(const secp256k1_fe *r) {
     uint64_t t0, t1, t2, t3, t4;
     uint64_t z0, z1;
     uint64_t x;

--- a/src/group.h
+++ b/src/group.h
@@ -53,6 +53,8 @@ static int secp256k1_ge_set_xquad_var(secp256k1_ge *r, const secp256k1_fe *x);
  *  for Y. Return value indicates whether the result is valid. */
 static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int odd);
 
+static void secp256k1_ge_set_xo_iso(secp256k1_ge *r, secp256k1_fe *rk, const secp256k1_fe *x);
+
 /** Check whether a group element is the point at infinity. */
 static int secp256k1_ge_is_infinity(const secp256k1_ge *a);
 
@@ -63,6 +65,8 @@ static void secp256k1_ge_neg(secp256k1_ge *r, const secp256k1_ge *a);
 
 /** Set a group element equal to another which is given in jacobian coordinates */
 static void secp256k1_ge_set_gej(secp256k1_ge *r, secp256k1_gej *a);
+
+static void secp256k1_ge_set_gej_zinv(secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_fe *zi);
 
 /** Set a batch of group elements equal to the inputs given in jacobian coordinates */
 static void secp256k1_ge_set_all_gej_var(size_t len, secp256k1_ge *r, const secp256k1_gej *a, const secp256k1_callback *cb);

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -185,7 +185,22 @@ static int secp256k1_ge_set_xo_var(secp256k1_ge *r, const secp256k1_fe *x, int o
         secp256k1_fe_negate(&r->y, &r->y, 1);
     }
     return 1;
+}
 
+static void secp256k1_ge_set_xo_iso(secp256k1_ge *r, secp256k1_fe *rk, const secp256k1_fe *x) {
+    secp256k1_fe t;
+
+    secp256k1_fe_sqr(&t, x);
+    secp256k1_fe_mul(&t, &t, x);
+    secp256k1_fe_set_int(rk, 7);
+    secp256k1_fe_add(rk, &t);           /* K = X^3 + 7 (2) */
+
+    /* Perhaps redundant as the equation cannot give 0 */
+    CHECK(!secp256k1_fe_normalizes_to_zero(rk));
+
+    r->infinity = 0;
+    secp256k1_fe_mul(&r->x, rk, x);     /* r->x = K*X (1) */
+    secp256k1_fe_sqr(&r->y, rk);        /* r->y = K^2 (1) */
 }
 
 static void secp256k1_gej_set_ge(secp256k1_gej *r, const secp256k1_ge *a) {

--- a/src/modules/ecdh/Makefile.am.include
+++ b/src/modules/ecdh/Makefile.am.include
@@ -2,7 +2,9 @@ include_HEADERS += include/secp256k1_ecdh.h
 noinst_HEADERS += src/modules/ecdh/main_impl.h
 noinst_HEADERS += src/modules/ecdh/tests_impl.h
 if USE_BENCHMARK
-noinst_PROGRAMS += bench_ecdh
+noinst_PROGRAMS += bench_ecdh bench_ecdh_opt
 bench_ecdh_SOURCES = src/bench_ecdh.c
 bench_ecdh_LDADD = libsecp256k1.la $(SECP_LIBS)
+bench_ecdh_opt_SOURCES = src/bench_ecdh_opt.c
+bench_ecdh_opt_LDADD = libsecp256k1.la $(SECP_LIBS)
 endif

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -10,7 +10,26 @@
 #include "include/secp256k1_ecdh.h"
 #include "ecmult_const_impl.h"
 
-int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar) {
+static void secp256k1_ecdh_hash(unsigned char *result, secp256k1_ge *pt) {
+    unsigned char x[32];
+    unsigned char y[1];
+    secp256k1_sha256_t sha;
+
+    /* Compute a hash of the point in compressed form
+     * Note we cannot use secp256k1_eckey_pubkey_serialize here since it does not
+     * expect its output to be secret and has a timing sidechannel. */
+    secp256k1_fe_normalize(&pt->x);
+    secp256k1_fe_normalize(&pt->y);
+    secp256k1_fe_get_b32(x, &pt->x);
+    y[0] = 0x02 | secp256k1_fe_is_odd(&pt->y);
+
+    secp256k1_sha256_initialize(&sha);
+    secp256k1_sha256_write(&sha, y, sizeof(y));
+    secp256k1_sha256_write(&sha, x, sizeof(x));
+    secp256k1_sha256_finalize(&sha, result);
+}
+
+int secp256k1_ecdh(const secp256k1_context *ctx, unsigned char *result, const secp256k1_pubkey *point, const unsigned char *scalar) {
     int ret = 0;
     int overflow = 0;
     secp256k1_gej res;
@@ -21,30 +40,81 @@ int secp256k1_ecdh(const secp256k1_context* ctx, unsigned char *result, const se
     ARG_CHECK(scalar != NULL);
     (void)ctx;
 
-    secp256k1_pubkey_load(ctx, &pt, point);
     secp256k1_scalar_set_b32(&s, scalar, &overflow);
     if (overflow || secp256k1_scalar_is_zero(&s)) {
         ret = 0;
     } else {
-        unsigned char x[32];
-        unsigned char y[1];
-        secp256k1_sha256_t sha;
-
+        secp256k1_pubkey_load(ctx, &pt, point);
         secp256k1_ecmult_const(&res, &pt, &s);
         secp256k1_ge_set_gej(&pt, &res);
-        /* Compute a hash of the point in compressed form
-         * Note we cannot use secp256k1_eckey_pubkey_serialize here since it does not
-         * expect its output to be secret and has a timing sidechannel. */
-        secp256k1_fe_normalize(&pt.x);
-        secp256k1_fe_normalize(&pt.y);
-        secp256k1_fe_get_b32(x, &pt.x);
-        y[0] = 0x02 | secp256k1_fe_is_odd(&pt.y);
-
-        secp256k1_sha256_initialize(&sha);
-        secp256k1_sha256_write(&sha, y, sizeof(y));
-        secp256k1_sha256_write(&sha, x, sizeof(x));
-        secp256k1_sha256_finalize(&sha, result);
+        secp256k1_ecdh_hash(result, &pt);
         ret = 1;
+    }
+
+    secp256k1_scalar_clear(&s);
+    return ret;
+}
+
+int secp256k1_ecdh_opt(const secp256k1_context *ctx, unsigned char *result, const unsigned char *pub, size_t publen, const unsigned char *scalar) {
+    int ret = 0;
+    int overflow = 0;
+    secp256k1_fe k, t, zi;
+    secp256k1_gej res;
+    secp256k1_ge pt;
+    secp256k1_scalar s;
+    ARG_CHECK(result != NULL);
+    ARG_CHECK(pub != NULL);
+    ARG_CHECK(scalar != NULL);
+    (void)ctx;
+
+    if (!(publen == 33 && (pub[0] == 0x02 || pub[0] == 0x03))) {
+        secp256k1_pubkey pubkey;
+        if (!secp256k1_ec_pubkey_parse(ctx, &pubkey, pub, publen)) {
+            return 0;
+        }
+        return secp256k1_ecdh(ctx, result, &pubkey, scalar);
+    }
+
+    if (!secp256k1_fe_set_b32(&t, &pub[1])) {
+        return 0;
+    }
+
+    secp256k1_scalar_set_b32(&s, scalar, &overflow);
+    if (overflow || secp256k1_scalar_is_zero(&s)) {
+        ret = 0;
+    } else {
+        /*
+         * Construct a point on an isomorphism described by u^2 == k (possibly on the twist)
+         */
+        secp256k1_ge_set_xo_iso(&pt, &k, &t);
+        secp256k1_ecmult_const(&res, &pt, &s);
+
+        /*
+         * Set 't' to the reciprocal sqrt of 'k' and 'zi' to the inverse of 'res.z'.
+         *
+         * TODO Infinity is a possibility because the twist has smaller order - the sqrt
+         *      would not be found in that case anyway, but need to handle possible 0 in res.z?
+         *      (Probably need cmovs based on res.infinity into 'ret' and 'res.z', to replace
+         *      the simple test here.)
+         * TODO Need secp256k1_fe_par_rsqrt_inv_var to be constant-time (and maybe handle 0?)
+         */
+        if (res.infinity || !secp256k1_fe_par_rsqrt_inv_var(&t, &zi, &k, &res.z)) {
+            ret = 0;
+        }
+        else {
+            secp256k1_fe_mul(&zi, &zi, &t);
+
+            /* Set (+/-)t = "pub.y" (from compressed input); adjust the sign of 'zi' accordingly */
+            secp256k1_fe_mul(&t, &t, &k);
+            secp256k1_fe_normalize(&t);
+            if (secp256k1_fe_is_odd(&t) != (pub[0] == 0x03)) {
+                secp256k1_fe_negate(&zi, &zi, 1);
+            }
+
+            secp256k1_ge_set_gej_zinv(&pt, &res, &zi);
+            secp256k1_ecdh_hash(result, &pt);
+            ret = 1;
+        }
     }
 
     secp256k1_scalar_clear(&s);

--- a/src/modules/ecdh/tests_impl.h
+++ b/src/modules/ecdh/tests_impl.h
@@ -41,7 +41,43 @@ void test_ecdh_generator_basepoint(void) {
     }
 }
 
-void test_bad_scalar(void) {
+void test_ecdh_opt_generator_basepoint(void) {
+    unsigned char s_one[32] = { 0 };
+    secp256k1_pubkey point[2];
+    int i;
+
+    s_one[31] = 1;
+    /* Check against pubkey creation when the basepoint is the generator */
+    for (i = 0; i < 100; ++i) {
+        secp256k1_sha256_t sha;
+        unsigned char s_b32[32];
+        unsigned char output_ecdh[32];
+        unsigned char output_ser[32];
+        unsigned char point_ser[33];
+        size_t point_ser_len = sizeof(point_ser);
+        secp256k1_scalar s;
+
+        random_scalar_order(&s);
+        secp256k1_scalar_get_b32(s_b32, &s);
+
+        /* compute using ECDH function */
+        CHECK(secp256k1_ec_pubkey_create(ctx, &point[0], s_one) == 1);
+        CHECK(secp256k1_ec_pubkey_serialize(ctx, point_ser, &point_ser_len, &point[0], SECP256K1_EC_COMPRESSED) == 1);
+        CHECK(point_ser_len == sizeof(point_ser));
+        CHECK(secp256k1_ecdh_opt(ctx, output_ecdh, point_ser, point_ser_len, s_b32) == 1);
+        /* compute "explicitly" */
+        CHECK(secp256k1_ec_pubkey_create(ctx, &point[1], s_b32) == 1);
+        CHECK(secp256k1_ec_pubkey_serialize(ctx, point_ser, &point_ser_len, &point[1], SECP256K1_EC_COMPRESSED) == 1);
+        CHECK(point_ser_len == sizeof(point_ser));
+        secp256k1_sha256_initialize(&sha);
+        secp256k1_sha256_write(&sha, point_ser, point_ser_len);
+        secp256k1_sha256_finalize(&sha, output_ser);
+        /* compare */
+        CHECK(memcmp(output_ecdh, output_ser, sizeof(output_ser)) == 0);
+    }
+}
+
+void test_ecdh_bad_scalar(void) {
     unsigned char s_zero[32] = { 0 };
     unsigned char s_overflow[32] = {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -67,9 +103,41 @@ void test_bad_scalar(void) {
     CHECK(secp256k1_ecdh(ctx, output, &point, s_overflow) == 1);
 }
 
+void test_ecdh_opt_bad_scalar(void) {
+    unsigned char s_zero[32] = { 0 };
+    unsigned char s_overflow[32] = {
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
+        0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b,
+        0xbf, 0xd2, 0x5e, 0x8c, 0xd0, 0x36, 0x41, 0x41
+    };
+    unsigned char s_rand[32] = { 0 };
+    unsigned char output[32];
+    secp256k1_scalar rand;
+    secp256k1_pubkey point;
+    unsigned char point_ser[33];
+    size_t point_ser_len = sizeof(point_ser);
+
+    /* Create random point */
+    random_scalar_order(&rand);
+    secp256k1_scalar_get_b32(s_rand, &rand);
+    CHECK(secp256k1_ec_pubkey_create(ctx, &point, s_rand) == 1);
+    CHECK(secp256k1_ec_pubkey_serialize(ctx, point_ser, &point_ser_len, &point, SECP256K1_EC_COMPRESSED) == 1);
+    CHECK(point_ser_len == sizeof(point_ser));
+
+    /* Try to multiply it by bad values */
+    CHECK(secp256k1_ecdh_opt(ctx, output, point_ser, point_ser_len, s_zero) == 0);
+    CHECK(secp256k1_ecdh_opt(ctx, output, point_ser, point_ser_len, s_overflow) == 0);
+    /* ...and a good one */
+    s_overflow[31] -= 1;
+    CHECK(secp256k1_ecdh_opt(ctx, output, point_ser, point_ser_len, s_overflow) == 1);
+}
+
 void run_ecdh_tests(void) {
     test_ecdh_generator_basepoint();
-    test_bad_scalar();
+    test_ecdh_opt_generator_basepoint();
+    test_ecdh_bad_scalar();
+    test_ecdh_opt_bad_scalar();
 }
 
 #endif


### PR DESCRIPTION
Builds on #362 as an alternative to #262.

Compressed points are moved onto an isomorphism (maybe the twist) instead of calling sqrt. After the scalar mult, parallel rsqrt/inv is used to reconstruct the correct output y-coordinate in parallel with the inversion of the z-coordinate. Total overhead vs uncompressed input is ~1%.

This implementation foregoes the jacobi check, meaning that the actual scalar multiplication could take place on a quadratic twist. This admits points with x == 0 as a possibility, but still not y == 0; the twist has a 37-bit, odd, cofactor. If this occurs, the parallel rsqrt/inv at the end will catch it and reject it. I think ECDH peers can already waste each other's time at will, so I don't think the delayed catch is a problem.

Do we know whether our formulae work "correctly" for the twist? Here we actually just need them not to crash (e.g. if an x==0 or P==INF turns up) in the scalar mult. Of course, we could always put the jacobi test back in, which has ~2% additional overhead.

Note:
The initial "decompression" produces (x,y) == (K.X, K^2) on the curve y^2 = x^3 + 7.K^3, with K != 0. If K is not a quadratic residue then this is a twist of the original curve.
