### PR TITLE
build: fix x86_64 asm detection for some compilers

### DIFF
--- a/build-aux/m4/bitcoin_secp.m4
+++ b/build-aux/m4/bitcoin_secp.m4
@@ -3,13 +3,13 @@ AC_DEFUN([SECP_INT128_CHECK],[
 has_int128=$ac_cv_type___int128
 ])
 
-dnl 
+dnl escape "$0x" below using the m4 quadrigaph @S|@, and escape it again with a \ for the shell.
 AC_DEFUN([SECP_64BIT_ASM_CHECK],[
 AC_MSG_CHECKING(for x86_64 assembly availability)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   #include <stdint.h>]],[[
   uint64_t a = 11, tmp;
-  __asm__ __volatile__("movq $0x100000000,%1; mulq %%rsi" : "+a"(a) : "S"(tmp) : "cc", "%rdx");
+  __asm__ __volatile__("movq \@S|@0x100000000,%1; mulq %%rsi" : "+a"(a) : "S"(tmp) : "cc", "%rdx");
   ]])],[has_64bit_asm=yes],[has_64bit_asm=no])
 AC_MSG_RESULT([$has_64bit_asm])
 ])


### PR DESCRIPTION
I'm not familiar enough with this asm syntax, there's probably a much simpler solution here, just switching to a test that doesn't need escaping.

I Noticed this on OSX with clang, though it likely happens elsewhere as well.
The result is disabled x86_64 asm.

Due to missing escaping, this $0 was interpreted as the function name
SECP_64BIT_ASM_CHECK, causing the compile-check to be broken on some compilers.

The actual check looked like this:
```c
int main()
{
  uint64_t a = 11, tmp;
  __asm__ __volatile__("movq SECP_64BIT_ASM_CHECKx100000000,%1; mulq %%rsi" : "+a"(a) : "S"(tmp) : "cc", "%rdx");
  return 0;
}
```
It seems even more odd that it compiled anywhere.