### PR TITLE
rename COPYING to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2013 Pieter Wuille
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -7,13 +9,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contrib/lax_der_parsing.c
+++ b/contrib/lax_der_parsing.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #include <string.h>

--- a/contrib/lax_der_parsing.h
+++ b/contrib/lax_der_parsing.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 /****

--- a/contrib/lax_der_privatekey_parsing.c
+++ b/contrib/lax_der_privatekey_parsing.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014, 2015 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #include <string.h>

--- a/contrib/lax_der_privatekey_parsing.h
+++ b/contrib/lax_der_privatekey_parsing.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014, 2015 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 /****

--- a/src/basic-config.h
+++ b/src/basic-config.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_BASIC_CONFIG_

--- a/src/bench.h
+++ b/src/bench.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_BENCH_H_

--- a/src/bench_ecdh.c
+++ b/src/bench_ecdh.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille, Andrew Poelstra                  *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #include <string.h>

--- a/src/bench_internal.c
+++ b/src/bench_internal.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 #include <stdio.h>
 

--- a/src/bench_recover.c
+++ b/src/bench_recover.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #include "include/secp256k1.h"

--- a/src/bench_schnorr_verify.c
+++ b/src/bench_schnorr_verify.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #include <stdio.h>

--- a/src/bench_sign.c
+++ b/src/bench_sign.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #include "include/secp256k1.h"

--- a/src/bench_verify.c
+++ b/src/bench_verify.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #include <stdio.h>

--- a/src/ecdsa.h
+++ b/src/ecdsa.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECDSA_

--- a/src/ecdsa_impl.h
+++ b/src/ecdsa_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 

--- a/src/eckey.h
+++ b/src/eckey.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECKEY_

--- a/src/eckey_impl.h
+++ b/src/eckey_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECKEY_IMPL_H_

--- a/src/ecmult.h
+++ b/src/ecmult.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECMULT_

--- a/src/ecmult_const.h
+++ b/src/ecmult_const.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECMULT_CONST_

--- a/src/ecmult_const_impl.h
+++ b/src/ecmult_const_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Pieter Wuille, Andrew Poelstra                  *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECMULT_CONST_IMPL_

--- a/src/ecmult_gen.h
+++ b/src/ecmult_gen.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECMULT_GEN_

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014, 2015 Pieter Wuille, Gregory Maxwell      *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECMULT_GEN_IMPL_H_

--- a/src/ecmult_impl.h
+++ b/src/ecmult_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_ECMULT_IMPL_H_

--- a/src/field.h
+++ b/src/field.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_FIELD_

--- a/src/field_10x26.h
+++ b/src/field_10x26.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_FIELD_REPR_

--- a/src/field_10x26_impl.h
+++ b/src/field_10x26_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_FIELD_REPR_IMPL_H_

--- a/src/field_5x52.h
+++ b/src/field_5x52.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_FIELD_REPR_

--- a/src/field_5x52_asm_impl.h
+++ b/src/field_5x52_asm_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2014 Diederik Huys, Pieter Wuille               *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 /**

--- a/src/field_5x52_impl.h
+++ b/src/field_5x52_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_FIELD_REPR_IMPL_H_

--- a/src/field_5x52_int128_impl.h
+++ b/src/field_5x52_int128_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_FIELD_INNER5X52_IMPL_H_

--- a/src/field_impl.h
+++ b/src/field_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_FIELD_IMPL_H_

--- a/src/gen_context.c
+++ b/src/gen_context.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014, 2015 Thomas Daede, Cory Fields           *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #define USE_BASIC_CONFIG 1

--- a/src/group.h
+++ b/src/group.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_GROUP_

--- a/src/group_impl.h
+++ b/src/group_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_GROUP_IMPL_H_

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_HASH_

--- a/src/hash_impl.h
+++ b/src/hash_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_HASH_IMPL_H_

--- a/src/modules/ecdh/main_impl.h
+++ b/src/modules/ecdh/main_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_MODULE_ECDH_MAIN_

--- a/src/modules/ecdh/tests_impl.h
+++ b/src/modules/ecdh/tests_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2015 Andrew Poelstra                                 *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_MODULE_ECDH_TESTS_

--- a/src/modules/recovery/main_impl.h
+++ b/src/modules/recovery/main_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_MODULE_RECOVERY_MAIN_

--- a/src/modules/recovery/tests_impl.h
+++ b/src/modules/recovery/tests_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_MODULE_RECOVERY_TESTS_

--- a/src/modules/schnorr/main_impl.h
+++ b/src/modules/schnorr/main_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef SECP256K1_MODULE_SCHNORR_MAIN

--- a/src/modules/schnorr/schnorr.h
+++ b/src/modules/schnorr/schnorr.h
@@ -1,7 +1,7 @@
 /***********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                               *
  * Distributed under the MIT software license, see the accompanying    *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php. *
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php. *
  ***********************************************************************/
 
 #ifndef _SECP256K1_MODULE_SCHNORR_H_

--- a/src/modules/schnorr/schnorr_impl.h
+++ b/src/modules/schnorr/schnorr_impl.h
@@ -1,7 +1,7 @@
 /***********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                               *
  * Distributed under the MIT software license, see the accompanying    *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php. *
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php. *
  ***********************************************************************/
 
 #ifndef _SECP256K1_SCHNORR_IMPL_H_

--- a/src/modules/schnorr/tests_impl.h
+++ b/src/modules/schnorr/tests_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef SECP256K1_MODULE_SCHNORR_TESTS

--- a/src/num.h
+++ b/src/num.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_NUM_

--- a/src/num_gmp.h
+++ b/src/num_gmp.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_NUM_REPR_

--- a/src/num_gmp_impl.h
+++ b/src/num_gmp_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_NUM_REPR_IMPL_H_

--- a/src/num_impl.h
+++ b/src/num_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_NUM_IMPL_H_

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_SCALAR_

--- a/src/scalar_4x64.h
+++ b/src/scalar_4x64.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_SCALAR_REPR_

--- a/src/scalar_4x64_impl.h
+++ b/src/scalar_4x64_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_SCALAR_REPR_IMPL_H_

--- a/src/scalar_8x32.h
+++ b/src/scalar_8x32.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_SCALAR_REPR_

--- a/src/scalar_8x32_impl.h
+++ b/src/scalar_8x32_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_SCALAR_REPR_IMPL_H_

--- a/src/scalar_impl.h
+++ b/src/scalar_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2014 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_SCALAR_IMPL_H_

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #define SECP256K1_BUILD (1)

--- a/src/testrand.h
+++ b/src/testrand.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_TESTRAND_H_

--- a/src/testrand_impl.h
+++ b/src/testrand_impl.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013-2015 Pieter Wuille                              *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_TESTRAND_IMPL_H_

--- a/src/tests.c
+++ b/src/tests.c
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014, 2015 Pieter Wuille, Gregory Maxwell      *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #if defined HAVE_CONFIG_H

--- a/src/util.h
+++ b/src/util.h
@@ -1,7 +1,7 @@
 /**********************************************************************
  * Copyright (c) 2013, 2014 Pieter Wuille                             *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file LICENSE or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
 
 #ifndef _SECP256K1_UTIL_H_


### PR DESCRIPTION
It's an unwritten rule to use COPYING for copyleft licenses (such as GPL) and LICENSE for non-copyleft licenses (such as MIT or BSD).

Also I changed the formatting slightly to match the template used at Github as this formatting seems to be what most projects are using nowadays.