### PR TITLE
Put precomputed ecmult table in build dir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,14 +86,14 @@ gen_%.o: src/gen_%.c
 $(gen_context_BIN): $(gen_context_OBJECTS)
 	$(CC_FOR_BUILD) $^ -o $@
 
-$(libsecp256k1_la_OBJECTS): src/ecmult_static_context.h
-$(tests_OBJECTS): src/ecmult_static_context.h
-$(bench_internal_OBJECTS): src/ecmult_static_context.h
+$(libsecp256k1_la_OBJECTS): ecmult_static_context.h
+$(tests_OBJECTS): ecmult_static_context.h
+$(bench_internal_OBJECTS): ecmult_static_context.h
 
-src/ecmult_static_context.h: $(gen_context_BIN)
+ecmult_static_context.h: $(gen_context_BIN)
 	./$(gen_context_BIN)
 
-CLEANFILES = $(gen_context_BIN) src/ecmult_static_context.h
+CLEANFILES = $(gen_context_BIN) ecmult_static_context.h
 endif
 
 EXTRA_DIST = autogen.sh src/gen_context.c src/basic-config.h

--- a/src/ecmult_gen_impl.h
+++ b/src/ecmult_gen_impl.h
@@ -12,7 +12,7 @@
 #include "ecmult_gen.h"
 #include "hash_impl.h"
 #ifdef USE_ECMULT_STATIC_PRECOMPUTATION
-#include "ecmult_static_context.h"
+#include <ecmult_static_context.h>
 #endif
 static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context *ctx) {
     ctx->prec = NULL;

--- a/src/gen_context.c
+++ b/src/gen_context.c
@@ -33,15 +33,15 @@ int main(int argc, char **argv) {
     (void)argc;
     (void)argv;
 
-    fp = fopen("src/ecmult_static_context.h","w");
+    fp = fopen("ecmult_static_context.h","w");
     if (fp == NULL) {
-        fprintf(stderr, "Could not open src/ecmult_static_context.h for writing!\n");
+        fprintf(stderr, "Could not open ecmult_static_context.h for writing!\n");
         return -1;
     }
     
     fprintf(fp, "#ifndef _SECP256K1_ECMULT_STATIC_CONTEXT_\n");
     fprintf(fp, "#define _SECP256K1_ECMULT_STATIC_CONTEXT_\n");
-    fprintf(fp, "#include \"group.h\"\n");
+    fprintf(fp, "/* user must include group.h before this file */\n");
     fprintf(fp, "#define SC SECP256K1_GE_STORAGE_CONST\n");
     fprintf(fp, "static const secp256k1_ge_storage secp256k1_ecmult_static_context[64][16] = {\n");
 


### PR DESCRIPTION
Include ecmult_static_context.h using the include path
so that it can be generated with a VPATH-style build in
a separate directory, when the original source directory
is not writable.

I'm not 100% sure this is the right way to accomplish
this. I'm down to make any changes needed to do it
properly.